### PR TITLE
Add lua filters for div tags

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - uses: r-lib/actions/setup-pandoc@master
+        with:
+          pandoc-version: '2.10' # NOTE: we need to add version catches for the tests.
 
       - name: Query dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9005
+Version: 0.0.0.9007
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     cli (>= 2.0.2),
     covr,
     withr,
+    jsonlite,
     varnish (>= 0.0.0.9001)
 Remotes: 
     carpentries/pegboard,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
 # sandpaper 0.0.0.9007
 
 * HTML will now be processed with pandoc lua filters that will do the following:
- - instructor and callout divs will be converted to `<aside>` tags
- - divs without H2 level headers will have them automatically inserted
- - divs with incorrect level headers will have them converted to H2
- - only divs in our list of carpentries divs will be converted
+  - overview block will be constructed from the teaching and exercises metadata
+    with the question and objectives blocks
+  - instructor and callout divs will be converted to `<aside>` tags
+  - divs without H2 level headers will have them automatically inserted
+  - divs with incorrect level headers will have them converted to H2
+  - only divs in our list of carpentries divs will be converted
+
+* README updated to reflect API changes
 
 # sandpaper 0.0.0.9006
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9007
+
+* HTML will now be processed with pandoc lua filters that will do the following:
+ - instructor and callout divs will be converted to `<aside>` tags
+ - divs without H2 level headers will have them automatically inserted
+ - divs with incorrect level headers will have them converted to H2
+ - only divs in our list of carpentries divs will be converted
+
 # sandpaper 0.0.0.9006
 
 Continuous integration functions added:

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -54,12 +54,15 @@ render_html <- function(path_in, ..., quiet = FALSE) {
     sep = "+"
   )
   from <- paste0("markdown", "-hard_line_breaks", "+", exts)
+  luaf <- system.file("filters", "lesson.lua", package = "sandpaper")
   args <- list(
     input = path_in, 
     output = htm, 
     from = from,
     to = "html", options = c(
-      "--indented-code-classes=sh", "--section-divs", "--mathjax", ...
+      "--indented-code-classes=sh", "--section-divs", "--mathjax",
+      paste0("--lua-filter=", luaf), 
+      ...
     ),
     verbose = FALSE
   )

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -42,6 +42,12 @@
 render_html <- function(path_in, ..., quiet = FALSE) {
   htm <- tempfile(fileext = ".html")
   on.exit(unlink(htm), add = TRUE)
+  args <- construct_pandoc_args(path_in, output = htm, to = "html", ...)
+  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args, show = !quiet)
+  paste(readLines(htm), collapse = "\n")
+}
+
+construct_pandoc_args <- function(path_in, output, to = "html", ...) {
   exts <- paste(
     "smart",
     "auto_identifiers",
@@ -55,17 +61,18 @@ render_html <- function(path_in, ..., quiet = FALSE) {
   )
   from <- paste0("markdown", "-hard_line_breaks", "+", exts)
   luaf <- system.file("filters", "lesson.lua", package = "sandpaper")
-  args <- list(
-    input = path_in, 
-    output = htm, 
-    from = from,
-    to = "html", options = c(
-      "--indented-code-classes=sh", "--section-divs", "--mathjax",
+  list(
+    input   = path_in,
+    output  = output,
+    from    = from,
+    to      = to,
+    options = c(
+      "--indented-code-classes=sh", 
+      "--section-divs", 
+      "--mathjax",
       paste0("--lua-filter=", luaf), 
       ...
     ),
     verbose = FALSE
   )
-  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args, show = !quiet)
-  paste(readLines(htm), collapse = "\n")
 }

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -13,7 +13,7 @@
 git_worktree_setup <- function (path = ".", dest_dir, branch = "gh-pages", remote = "origin") {
 
   no_branch <- !git_has_remote_branch(remote, branch)
-  
+
   # create the branch if it doesn't exist
   if (no_branch) {
     old_branch <- gert::git_branch(repo = path)
@@ -49,7 +49,7 @@ git_has_remote_branch <- function (remote, branch) {
   git(
     "ls-remote", "--quiet", "--exit-code", remote, branch, 
     echo = FALSE, echo_cmd = FALSE, error_on_status = FALSE
-  )$status == 0
+    )$status == 0
 }
 
 # Add a branch to a folder as a worktree
@@ -66,24 +66,24 @@ github_worktree_add <- function (dir, remote, branch) {
 # Commit on a worktree
 # Modified from pkgdown:::github_push by Hadley Wickham
 github_worktree_commit <- function (dir, commit_message, remote, branch) {
-    force(commit_message)
-    if (requireNamespace("cli", quietly = TRUE))
-      cli::rule("Committing", line = "c")
-    # ZNK: add explicit check for withr
-    if (!requireNamespace("withr", quietly = TRUE))
-      stop("withr must be installed")
-    withr::with_dir(dir, {
-      # ZNK: Change to gert::git_add(); only commit if we have something to add
-      added <- gert::git_add(".", repo = dir)
-      if (nrow(added) == 0) {
-        message("nothing to commit!")
-        return(NULL)
-      }
-      git("commit", "--allow-empty", "-m", commit_message)
-      cli::rule("Deploying", line = 1)
-      git("remote", "-v")
-      git("push", "--force", remote, paste0("HEAD:", branch))
-    })
+  force(commit_message)
+  if (requireNamespace("cli", quietly = TRUE))
+    cli::rule("Committing", line = "c")
+  # ZNK: add explicit check for withr
+  if (!requireNamespace("withr", quietly = TRUE))
+    stop("withr must be installed")
+  withr::with_dir(dir, {
+    # ZNK: Change to gert::git_add(); only commit if we have something to add
+    added <- gert::git_add(".", repo = dir)
+    if (nrow(added) == 0) {
+      message("nothing to commit!")
+      return(NULL)
+    }
+    git("commit", "--allow-empty", "-m", commit_message)
+    cli::rule("Deploying", line = 1)
+    git("remote", "-v")
+    git("push", "--force", remote, paste0("HEAD:", branch))
+  })
 }
 
 # Remove a git worktree

--- a/README.Rmd
+++ b/README.Rmd
@@ -179,7 +179,8 @@ Accessors
 **Continuous Integration Utilities**
 
  - `ci_deploy()` builds and deploys the lesson on CI from the source files
- - `ci_deploy_site()` deploys the lesson on CI from pre-rendered markdown files
+ - `ci_build_markdown()` builds the markdown files on CI from the source and deploys them to the markdown branch. 
+ - `ci_build_site()` deploys the lesson on CI from pre-rendered markdown files
  - `ci_release()` builds and deploys the lesson on CI from the source files and adds a release tag
 
 Cleanup
@@ -340,11 +341,11 @@ Because css and js libraries may need updating before any lesson material does,
 a step can be created just for rebuilding the site that uses:
 
 ```{r}
-sandpaper::ci_deploy_site(branch = "gh-pages")
+sandpaper::ci_build_site(branch = "gh-pages")
 ```
 
 When a lesson is given a release, the current site folder needs to be duplicated
-to a versioned folder and a tag needs to be added to the "md-outputs" branch:
+to a versioned folder and a tag needs to be added to the `md-outputs` branch:
 
 ```{r}
 sandpaper::ci_release(tag = "0.1", md_branch = "md-outputs", site_branch = "gh-pages")

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Bryan’s](https://jennybryan.org/) work with the
 > Please note: {sandpaper} is very much a work in progress. At the
 > moment, the only thing that is real is the README to serve as a
 > roadmap for the future. Please [open an
-> issue](https://github.com/carpentries/sandpaper/issues/new) if you have
-> any comments or suggestions\!
+> issue](https://github.com/carpentries/sandpaper/issues/new) if you
+> have any comments or suggestions\!
 
 -----
 
@@ -200,7 +200,9 @@ Accessors
 
   - `ci_deploy()` builds and deploys the lesson on CI from the source
     files
-  - `ci_deploy_site()` deploys the lesson on CI from pre-rendered
+  - `ci_build_markdown()` builds the markdown files on CI from the
+    source and deploys them to the markdown branch.
+  - `ci_build_site()` deploys the lesson on CI from pre-rendered
     markdown files
   - `ci_release()` builds and deploys the lesson on CI from the source
     files and adds a release tag
@@ -355,22 +357,23 @@ most straightforward function is:
 sandpaper::ci_deploy(md_branch = "md-outputs", site_branch = "gh-pages")
 ```
 
-This will render the markdown files in the `vignettes/` folder of the
-“md-outputs” branch and then build the site from that folder and
-deploy it to the “gh-pages” branch using the
-[{pkgdown}](https://github.com/r-lib/pkgdown#readme) machinery.
+This functionw will create [git
+worktrees](https://git-scm.com/docs/git-worktree) for the orphan
+`md-outputs` branch in the `site/built` folder and the orphan `gh-pages`
+branch in the `site/docs` folder. After that, we generate the site as
+normal.
 
 Because css and js libraries may need updating before any lesson
 material does, a step can be created just for rebuilding the site that
 uses:
 
 ``` r
-sandpaper::ci_deploy_site(branch = "gh-pages")
+sandpaper::ci_build_site(branch = "gh-pages")
 ```
 
 When a lesson is given a release, the current site folder needs to be
 duplicated to a versioned folder and a tag needs to be added to the
-“md-outputs” branch:
+`md-outputs` branch:
 
 ``` r
 sandpaper::ci_release(tag = "0.1", md_branch = "md-outputs", site_branch = "gh-pages")

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -1,3 +1,69 @@
+local text = require('text')
+
+-- Lua Set for checking existence of item
+-- https://www.lua.org/pil/11.5.html
+function Set (list)
+  local set = {}
+  for _, l in ipairs(list) do set[l] = true end
+  return set
+end
+local blocks = Set{
+  "callout",
+  "objectives",
+  "challenge",
+  "prereq",
+  "checklist",
+  "solution",
+  "discussion",
+  "testimonial",
+  "keypoints",
+}
+
+-- get the timing elements from the metadata and store them in a global var
+local timings = {}
+function get_timings (meta)
+  for k, v in pairs(meta) do
+    if type(v) == 'table' and v.t == 'MetaInlines' then
+      vars[k] = {table.unpack(v)}
+    end
+  end
+end
+
+--[[
+-- TODO: Create combination Timings, Questions, and Objectives block:
+--
+-- This block in practice looks like this, but I think it could probably be
+-- improved.
+--
+-- <div class="objectives">
+--   <div class="row">
+--     <div class="col-md-3">
+--       pandoc.Strong { pandoc.Str "Teaching:" } vars["teaching"]..
+--       pandoc.LineBreak..
+--       pandoc.Strong { pandoc.Str "Exercises:" } vars["exercises"]
+--     </div>
+--     <div class="col-md-9">
+--       pandoc.Strong { pandoc.Str "Questions" }..
+--       pandoc.LineBreak..
+--       pandoc.BulletList {  }
+--     </div>
+--   </div>
+--   <div class="row">
+--     <div class="col-md-3">
+--     </div>
+--     <div class="col-md-9">
+--       pandoc.Strong { pandoc.Str "Objectives" }..
+--       pandoc.LineBreak..
+--       pandoc.BulletList {  }
+--     </div>
+--   </div>
+-- </div>
+function first_block(questions, objectives)
+  local res = pandoc.List:new{}
+
+end
+--]]
+
 -- Convert Div elements to semantic HTML <aside> tags
 --
 -- NOTE: This destructively converts div tags, so do not apply this to a div
@@ -27,24 +93,13 @@ function step_aside(el, i)
   for _, block in ipairs(el.content) do
     table.insert(res, block)
   end
-  
+
   -- Step 3: insert the HTML closing tag
   table.insert(res, pandoc.RawBlock('html', '</aside>'))
 
   return res
 end
 
-local text = require('text')
--- TODO: figure out how to get matching to work
-local our_classes = "callout"..
-  "|".."objectives"..
-  "|".."challenge"..
-  "|".."prereq"..
-  "|".."checklist"..
-  "|".."solution"..
-  "|".."discussion"..
-  "|".."testimonial"..
-  "|".."keypoints"
 -- Add a header to a Div element if it doesn't exist
 -- 
 -- @param el a pandoc.Div element
@@ -52,9 +107,9 @@ local our_classes = "callout"..
 -- @return the element with a header if it doesn't exist
 function head_of_the_class(el)
 
-  -- bail early if there is no class
+  -- bail early if there is no class or it's not one of ours
   local class = pandoc.utils.stringify(el.classes[1])
-  if class == nil then -- or not class:match(our_classes) then
+  if class == nil or blocks[class] == nil then
     return el
   end
 
@@ -75,6 +130,8 @@ function head_of_the_class(el)
 
   return el
 end
+
+
 
 -- Deal with fenced divs
 Div = function(el)

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -35,6 +35,16 @@ function step_aside(el, i)
 end
 
 local text = require('text')
+-- TODO: figure out how to get matching to work
+local our_classes = "callout"..
+  "|".."objectives"..
+  "|".."challenge"..
+  "|".."prereq"..
+  "|".."checklist"..
+  "|".."solution"..
+  "|".."discussion"..
+  "|".."testimonial"..
+  "|".."keypoints"
 -- Add a header to a Div element if it doesn't exist
 -- 
 -- @param el a pandoc.Div element
@@ -43,8 +53,8 @@ local text = require('text')
 function head_of_the_class(el)
 
   -- bail early if there is no class
-  local class = el.classes[1]
-  if class == nil then
+  local class = pandoc.utils.stringify(el.classes[1])
+  if class == nil then -- or not class:match(our_classes) then
     return el
   end
 
@@ -56,7 +66,9 @@ function head_of_the_class(el)
     local lass = text.sub(class, 2, -1)
     local header = pandoc.Header(2, C..lass)
     table.insert(el.content, 1, header)
-  elseif header ~= 2 then
+  end
+
+  if header ~= 2 then
     -- force the header level to be 2
     el.content[1].level = 2
   end

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -54,7 +54,8 @@ function head_of_the_class(el)
     -- capitalize the first letter and insert it at the top of the block
     local C = text.upper(text.sub(class, 1, 1))
     local lass = text.sub(class, 2, -1)
-    el.content:insert(1, pandoc.Header(2, C..lass))
+    local header = pandoc.Header(2, C..lass)
+    table.insert(el.content, 1, header)
   elseif header ~= 2 then
     -- force the header level to be 2
     el.content[1].level = 2

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -191,6 +191,8 @@ handle_our_divs = function(el)
     questions = el
     if objectives ~= nil then
       return first_block()
+    else 
+      return nil
     end
   end
 
@@ -199,6 +201,8 @@ handle_our_divs = function(el)
     objectives = el
     if questions ~= nil then
       return first_block()
+    else 
+      return nil
     end
   end
 

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -32,34 +32,16 @@ function get_timings (meta)
 end
 
 --[[
--- TODO: Create combination Timings, Questions, and Objectives block:
+-- Create Overview block that is a combination of questions and objectives.
 --
--- This block in practice looks like this, but I think it could probably be
--- improved.
+-- This was originally taken care of by Jekyll, but since we are not necessarily
+-- relying on a logic-based templating language (liquid can diaf), we can create
+-- this here. 
 --
--- <div class="objectives">
---   <div class="row">
---     <div class="col-md-3">
---       pandoc.Strong { pandoc.Str "Teaching:" } timings["teaching"]..
---       pandoc.LineBreak..
---       pandoc.Strong { pandoc.Str "Exercises:" } timings["exercises"]
---     </div>
---     <div class="col-md-9">
---       pandoc.Strong { pandoc.Str "Questions" }..
---       pandoc.LineBreak..
---       pandoc.BulletList {  }
---     </div>
---   </div>
---   <div class="row">
---     <div class="col-md-3">
---     </div>
---     <div class="col-md-9">
---       pandoc.Strong { pandoc.Str "Objectives" }..
---       pandoc.LineBreak..
---       pandoc.BulletList {  }
---     </div>
---   </div>
--- </div>
+-- This relies on a couple of things
+--
+-- Meta: teaching and exercises
+-- Body: questions and objectives. 
 --]]
 function first_block()
   local res = pandoc.List:new{}
@@ -68,6 +50,10 @@ function first_block()
   local html_close
   local teach = pandoc.utils.stringify(timings["teaching"])
   local exercise = pandoc.utils.stringify(timings["exercises"])
+  -- At the moment, I'm inserting raw HTML blocks here because that's how they
+  -- would appear if they were written in markdown, but it is also possible to
+  -- do this in a native pandoc way, but I get the feeling that these will
+  -- change in the future, so I didn't want to spend too much time on it. 
   html_open = pandoc.RawBlock('html', [[
   <div class="row">
     <div class="col-md-3">

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -34,16 +34,53 @@ function step_aside(el, i)
   return res
 end
 
+local text = require('text')
+-- Add a header to a Div element if it doesn't exist
+-- 
+-- @param el a pandoc.Div element
+--
+-- @return the element with a header if it doesn't exist
+function head_of_the_class(el)
+
+  -- bail early if there is no class
+  local class = el.classes[1]
+  if class == nil then
+    return el
+  end
+
+  -- check if the header exists
+  local header = el.content[1].level
+  if header == nil then
+    -- capitalize the first letter and insert it at the top of the block
+    local C = text.upper(text.sub(class, 1, 1))
+    local lass = text.sub(class, 2, -1)
+    el.content:insert(1, pandoc.Header(2, C..lass))
+  elseif header ~= 2 then
+    -- force the header level to be 2
+    el.content[1].level = 2
+  end
+
+  return el
+end
+
 -- Deal with fenced divs
 Div = function(el)
+
+  -- Instructor notes should be aside tags
   v,i = el.classes:find("instructor")
   if i ~= nil then
     return step_aside(el, i)
   end
+
+  -- All other Div tags should have level 2 headers
+  head_of_the_class(el)
+
+  -- Callouts should be asides
   v,i = el.classes:find("callout")
   if i ~= nil then
     return step_aside(el, i)
   end
+
   return el
 end
 

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -192,7 +192,7 @@ handle_our_divs = function(el)
     if objectives ~= nil then
       return first_block()
     else 
-      return nil
+      return pandoc.Null()
     end
   end
 
@@ -202,7 +202,7 @@ handle_our_divs = function(el)
     if questions ~= nil then
       return first_block()
     else 
-      return nil
+      return pandoc.Null()
     end
   end
 

--- a/inst/filters/lesson.lua
+++ b/inst/filters/lesson.lua
@@ -1,0 +1,49 @@
+-- Convert Div elements to semantic HTML <aside> tags
+--
+-- NOTE: This destructively converts div tags, so do not apply this to a div
+-- tag that has more than one associated class.
+--
+-- @param el a pandoc Div element
+-- @param i the index of the class element
+-- 
+-- @return a pandoc List element, with the contents of the Div block surrounded 
+-- by opening and closing <aside> html elements
+function step_aside(el, i)
+  -- create a new pandoc element, add raw HTML, 
+  -- and fill it with the content of the div block
+  local class = el.classes[i]
+  local html
+  local res = pandoc.List:new{}
+
+  -- remove this class from the div tag
+  el.classes[i] = nil
+
+  -- Step 1: insert the HTML opening tag
+  html = '<aside class="'..class..'">'
+
+  table.insert(res, pandoc.RawBlock('html', html))
+
+  -- Step 2: insert the content of the Div block into the output List
+  for _, block in ipairs(el.content) do
+    table.insert(res, block)
+  end
+  
+  -- Step 3: insert the HTML closing tag
+  table.insert(res, pandoc.RawBlock('html', '</aside>'))
+
+  return res
+end
+
+-- Deal with fenced divs
+Div = function(el)
+  v,i = el.classes:find("instructor")
+  if i ~= nil then
+    return step_aside(el, i)
+  end
+  v,i = el.classes:find("callout")
+  if i ~= nil then
+    return step_aside(el, i)
+  end
+  return el
+end
+

--- a/inst/templates/episode-template.txt
+++ b/inst/templates/episode-template.txt
@@ -26,15 +26,11 @@ part of the html page.
 
 :::::::::::::::: questions :::::::::::::::::::::
 
-## Questions
-
 - How do you write a lesson using RMarkdown and `{sandpaper}`?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::: objectives ::::::::::::::::::::
-
-## Objectives
 
 - Explain how to use markdown with the new lesson template
 - Demonstrate how to include pieces of code, figures, and nested challenge blocks
@@ -42,8 +38,6 @@ part of the html page.
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::: keypoints :::::::::::::::::::::
-
-## Keypoints
 
 - Use `.Rmd` files for lessons even if you don't need to generate any code
 - Run `sandpaper::check_lesson()` to identify any issues with your lesson
@@ -76,8 +70,6 @@ paste("This", "new", "template", "looks", "good")
 
 :::::::::::::::::::::::: solution 
 
-## Nest Solution
- 
 You can add a line with at least three colons and a `solution` tag.
 
 :::::::::::::::::::::::::::::::::

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -1,3 +1,512 @@
+# pandoc_json is rendered correctly
+
+    Code
+      jsonlite::prettify(readLines(out), indent = 2)
+    Output
+      {
+        "blocks": [
+          {
+            "t": "Null"
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "<div class=\"objectives\">"
+            ]
+          },
+          {
+            "t": "Header",
+            "c": [
+              2,
+              [
+                "",
+                [
+      
+                ],
+                [
+      
+                ]
+              ],
+              [
+                {
+                  "t": "Str",
+                  "c": "Overview"
+                }
+              ]
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "  <div class=\"row\">\n    <div class=\"col-md-3\">\n  "
+            ]
+          },
+          {
+            "t": "Para",
+            "c": [
+              {
+                "t": "Strong",
+                "c": [
+                  {
+                    "t": "Str",
+                    "c": "Teaching: "
+                  }
+                ]
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "6"
+              },
+              {
+                "t": "LineBreak"
+              },
+              {
+                "t": "Strong",
+                "c": [
+                  {
+                    "t": "Str",
+                    "c": "Exercises: "
+                  }
+                ]
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "9"
+              }
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "    <\/div>\n    <div class=\"col-md-9\">\n  "
+            ]
+          },
+          {
+            "t": "Para",
+            "c": [
+              {
+                "t": "Strong",
+                "c": [
+                  {
+                    "t": "Str",
+                    "c": "Questions"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "t": "BulletList",
+            "c": [
+              [
+                {
+                  "t": "Plain",
+                  "c": [
+                    {
+                      "t": "Str",
+                      "c": "What’s"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "the"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "point?"
+                    }
+                  ]
+                }
+              ]
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "    <\/div>\n  <\/div>\n  "
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "  <div class=\"row\">\n    <div class=\"col-md-3\">\n  "
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "    <\/div>\n    <div class=\"col-md-9\">\n  "
+            ]
+          },
+          {
+            "t": "Para",
+            "c": [
+              {
+                "t": "Strong",
+                "c": [
+                  {
+                    "t": "Str",
+                    "c": "Objectives"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "t": "BulletList",
+            "c": [
+              [
+                {
+                  "t": "Plain",
+                  "c": [
+                    {
+                      "t": "Str",
+                      "c": "Bake"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "him"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "away,"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "toys"
+                    }
+                  ]
+                }
+              ]
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "    <\/div>\n  <\/div>\n  "
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "<\/div>"
+            ]
+          },
+          {
+            "t": "Header",
+            "c": [
+              1,
+              [
+                "markdown",
+                [
+      
+                ],
+                [
+      
+                ]
+              ],
+              [
+                {
+                  "t": "Str",
+                  "c": "Markdown"
+                }
+              ]
+            ]
+          },
+          {
+            "t": "Div",
+            "c": [
+              [
+                "",
+                [
+                  "challenge"
+                ],
+                [
+      
+                ]
+              ],
+              [
+                {
+                  "t": "Header",
+                  "c": [
+                    2,
+                    [
+                      "",
+                      [
+      
+                      ],
+                      [
+      
+                      ]
+                    ],
+                    [
+                      {
+                        "t": "Str",
+                        "c": "Challenge"
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "t": "Para",
+                  "c": [
+                    {
+                      "t": "Str",
+                      "c": "How"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "do"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "you"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "write"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "markdown"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "divs?"
+                    }
+                  ]
+                },
+                {
+                  "t": "Div",
+                  "c": [
+                    [
+                      "",
+                      [
+                        "solution"
+                      ],
+                      [
+      
+                      ]
+                    ],
+                    [
+                      {
+                        "t": "Header",
+                        "c": [
+                          2,
+                          [
+                            "write-now",
+                            [
+      
+                            ],
+                            [
+      
+                            ]
+                          ],
+                          [
+                            {
+                              "t": "Str",
+                              "c": "Write"
+                            },
+                            {
+                              "t": "Space"
+                            },
+                            {
+                              "t": "Str",
+                              "c": "now"
+                            }
+                          ]
+                        ]
+                      },
+                      {
+                        "t": "Para",
+                        "c": [
+                          {
+                            "t": "Str",
+                            "c": "just"
+                          },
+                          {
+                            "t": "Space"
+                          },
+                          {
+                            "t": "Str",
+                            "c": "write"
+                          },
+                          {
+                            "t": "Space"
+                          },
+                          {
+                            "t": "Str",
+                            "c": "it,"
+                          },
+                          {
+                            "t": "Space"
+                          },
+                          {
+                            "t": "Str",
+                            "c": "silly."
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "<aside class=\"instructor\">"
+            ]
+          },
+          {
+            "t": "Para",
+            "c": [
+              {
+                "t": "Str",
+                "c": "This"
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "should"
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "be"
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "aside"
+              }
+            ]
+          },
+          {
+            "t": "RawBlock",
+            "c": [
+              "html",
+              "<\/aside>"
+            ]
+          },
+          {
+            "t": "Div",
+            "c": [
+              [
+                "",
+                [
+                  "nothing"
+                ],
+                [
+      
+                ]
+              ],
+              [
+                {
+                  "t": "Para",
+                  "c": [
+                    {
+                      "t": "Str",
+                      "c": "This"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "should"
+                    },
+                    {
+                      "t": "Space"
+                    },
+                    {
+                      "t": "Str",
+                      "c": "be"
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        ],
+        "pandoc-api-version": [
+          1,
+          21
+        ],
+        "meta": {
+          "exercises": {
+            "t": "MetaInlines",
+            "c": [
+              {
+                "t": "Str",
+                "c": "9"
+              }
+            ]
+          },
+          "teaching": {
+            "t": "MetaInlines",
+            "c": [
+              {
+                "t": "Str",
+                "c": "6"
+              }
+            ]
+          }
+        }
+      }
+       
+
 # render_html applies the internal lua filter
 
     Code

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -1,0 +1,22 @@
+# render_html applies the internal lua filter
+
+    Code
+      cat(res)
+    Output
+      <div id="markdown" class="section level1">
+      <h1>Markdown</h1>
+      <div class="challenge">
+      <div class="section level2">
+      <h2>Challenge</h2>
+      <p>How do you write markdown divs?</p>
+      </div>
+      <div id="write-now" class="section level2 solution">
+      <h2>Write now</h2>
+      <p>just write it, silly.</p>
+      </div>
+      </div>
+      <aside class="instructor">
+      <p>This should be aside</p>
+      </aside>
+      </div>
+

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -18,5 +18,8 @@
       <aside class="instructor">
       <p>This should be aside</p>
       </aside>
+      <div class="nothing">
+      <p>This should be</p>
+      </div>
       </div>
 

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -3,6 +3,39 @@
     Code
       cat(res)
     Output
+      <div class="objectives">
+      <div class="section level2">
+      <h2>Overview</h2>
+        <div class="row">
+          <div class="col-md-3">
+        
+      <p><strong>Teaching: </strong> 6<br />
+      <strong>Exercises: </strong> 9</p>
+          </div>
+          <div class="col-md-9">
+        
+      <p><strong>Questions</strong></p>
+      <ul>
+      <li>What’s the point?</li>
+      </ul>
+          </div>
+        </div>
+        
+        <div class="row">
+          <div class="col-md-3">
+        
+          </div>
+          <div class="col-md-9">
+        
+      <p><strong>Objectives</strong></p>
+      <ul>
+      <li>Bake him away, toys</li>
+      </ul>
+          </div>
+        </div>
+        
+      </div>
+      </div>
       <div id="markdown" class="section level1">
       <h1>Markdown</h1>
       <div class="challenge">

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -1,0 +1,58 @@
+ex <- c("# Markdown", 
+  "", 
+  "::: challenge", 
+  "", 
+  "How do you write markdown divs?",
+  "", 
+  "::: solution",
+  "",
+  "# Write now",
+  "",
+  "just write it, silly.",
+  ":::",
+  ":::",
+  "", 
+  "::: instructor", 
+  "", 
+  "This should be aside",
+  "", 
+  ":::",
+  NULL
+)
+test_that("render_html applies the internal lua filter", {
+
+  tmp <- fs::file_temp()
+  withr::local_file(tmp)
+
+  writeLines(ex, tmp)
+  res <- render_html(tmp)
+  expect_snapshot(cat(res))
+  # Challenge header automatically added
+  expect_match(res, "<h2>Challenge</h2>", fixed = TRUE)
+  # Solution header modified
+  expect_match(res, "<h2>Write now</h2>", fixed = TRUE)
+  # Aside tag applied
+  expect_match(res, "<aside class=\"instructor\">", fixed = TRUE)
+  # Instructor header doesn't need to exist
+  expect_failure(expect_match(res, "<h2>Instructor</h2>", fixed = TRUE))
+
+
+})
+
+test_that("render_html applies external lua filters", {
+
+  tmp <- fs::file_temp()
+  lua <- fs::file_temp()
+  withr::local_file(tmp, lua)
+
+  writeLines(ex, tmp)
+  lu <- c("Str = function (elem)",
+    "  if elem.text == 'markdown' then",
+    "    return pandoc.Emph {pandoc.Str 'mowdrank'}",
+    "  end",
+    "end")
+  writeLines(lu, lua)
+  res <- render_html(tmp, paste0("--lua-filter=", lua))
+  expect_match(res, "<em>mowdrank</em> divs", fixed = TRUE)
+  
+})

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -42,6 +42,22 @@ ex <- c("---",
   ":::",
   NULL
 )
+
+test_that("pandoc_json is rendered correctly", {
+  
+  skip_if_not_installed("jsonlite")
+  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  tmp <- fs::file_temp()
+  out <- fs::file_temp()
+  withr::local_file(tmp, out)
+
+  writeLines(ex, tmp)
+  args <- construct_pandoc_args(tmp, out, to = "json")
+  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args)
+  expect_snapshot(jsonlite::prettify(readLines(out), indent = 2))
+
+})
+
 test_that("render_html applies the internal lua filter", {
 
   tmp <- fs::file_temp()

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -28,13 +28,13 @@ test_that("render_html applies the internal lua filter", {
   res <- render_html(tmp)
   expect_snapshot(cat(res))
   # Challenge header automatically added
-  expect_match(res, "<h2>Challenge</h2>", fixed = TRUE)
+  expect_match(res, "Challenge</h2>", fixed = TRUE)
   # Solution header modified
-  expect_match(res, "<h2>Write now</h2>", fixed = TRUE)
+  expect_match(res, "Write now</h2>", fixed = TRUE)
   # Aside tag applied
   expect_match(res, "<aside class=\"instructor\">", fixed = TRUE)
   # Instructor header doesn't need to exist
-  expect_failure(expect_match(res, "<h2>Instructor</h2>", fixed = TRUE))
+  expect_failure(expect_match(res, "Instructor</h2>", fixed = TRUE))
 
 
 })

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -1,4 +1,21 @@
-ex <- c("# Markdown", 
+ex <- c("---",
+  "teaching: 6",
+  "exercises: 9",
+  "---",
+  "",
+  "::: questions", 
+  "", 
+  " - What's the point?",
+  "", 
+  ":::",
+  "",
+  "::: objectives", 
+  "", 
+  " - Bake him away, toys",
+  "", 
+  ":::",
+  "",
+  "# Markdown", 
   "", 
   "::: challenge", 
   "", 
@@ -37,6 +54,15 @@ test_that("render_html applies the internal lua filter", {
     expect_snapshot(cat(res))
   }
 
+  # Metadata blocks are parsed
+  expect_match(res, "div class=\"row\"", fixed = TRUE)
+  expect_match(res, "div class=\"col-md-3\"", fixed = TRUE)
+  expect_match(res, "div class=\"col-md-9\"", fixed = TRUE)
+  expect_match(res, "div class=\"objectives\"", fixed = TRUE)
+  expect_match(res, "Teaching: ", fixed = TRUE)
+  expect_match(res, "Exercises: ", fixed = TRUE)
+  expect_match(res, "Questions", fixed = TRUE)
+  expect_match(res, "Objectives", fixed = TRUE)
   # Challenge header automatically added
   expect_match(res, "Challenge</h2>", fixed = TRUE)
   # Solution header modified
@@ -48,7 +74,6 @@ test_that("render_html applies the internal lua filter", {
   # Div class nothing should be left alone
   expect_match(res, "div class=\"nothing\"", fixed = TRUE)
   expect_failure(expect_match(res, "Nothing</h2>", fixed = TRUE))
-
 
 })
 

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -17,6 +17,12 @@ ex <- c("# Markdown",
   "This should be aside",
   "", 
   ":::",
+  "", 
+  "::: nothing", 
+  "", 
+  "This should be",
+  "", 
+  ":::",
   NULL
 )
 test_that("render_html applies the internal lua filter", {
@@ -26,7 +32,11 @@ test_that("render_html applies the internal lua filter", {
 
   writeLines(ex, tmp)
   res <- render_html(tmp)
-  expect_snapshot(cat(res))
+  
+  if (rmarkdown::pandoc_available("2.10")) {
+    expect_snapshot(cat(res))
+  }
+
   # Challenge header automatically added
   expect_match(res, "Challenge</h2>", fixed = TRUE)
   # Solution header modified
@@ -35,6 +45,9 @@ test_that("render_html applies the internal lua filter", {
   expect_match(res, "<aside class=\"instructor\">", fixed = TRUE)
   # Instructor header doesn't need to exist
   expect_failure(expect_match(res, "Instructor</h2>", fixed = TRUE))
+  # Div class nothing should be left alone
+  expect_match(res, "div class=\"nothing\"", fixed = TRUE)
+  expect_failure(expect_match(res, "Nothing</h2>", fixed = TRUE))
 
 
 })


### PR DESCRIPTION
This adds lua filters to manipulate the lesson content when converting from markdown to html. 

Note: I'm using 2.10 for testing at the moment, which is going to give me a lot of grief because there are differences between how 2.7.1 (current RStudio default) and 2.10 handle things. 

 - instructor and callout div tags are recast as HTML `<aside>` blocks.
 - all div tags with our classes (except for instructor) will have the class as a level 2 header

Merging this will address #26 