### PR TITLE
remove remotes section in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     knitr,
     rmarkdown,
     rprojroot,
-    usethis,
+    usethis (>= 2.0.0),
     utils,
     tools,
     whisker,
@@ -37,17 +37,13 @@ Suggests:
     withr,
     jsonlite,
     varnish (>= 0.0.0.9001)
-Remotes: 
-    carpentries/pegboard,
-    zkamvar/varnish,
-    r-lib/gh,
-    r-lib/usethis
+Additional_repositories: https://zkamvar.github.io/drat/
 Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-URL: https://github.com/carpentries/sandpaper
-BugReports: https://github.com/carpentries/sandpaper/issues
+URL: https://github.com/carpentries/sandpaper/
+BugReports: https://github.com/carpentries/sandpaper/issues/
 VignetteBuilder: knitr


### PR DESCRIPTION
The {usethis} package is now on CRAN and my drat repository builds every day, so this reduces the number of github api calls. 