### PR TITLE
change strategy of searching for rendered images

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,18 @@
+# sandpaper 0.0.0.9009
+
+BUG FIX
+-------
+
+* A bug introduced in version 0.0.0.9008 was fixed. This bug improperly used 
+  regex resulting in the accidental removal of cached rendered images. This
+  fixes issue #49
+* Rendered images now have the prefix of `{SOURCE}-rendered-` in the 
+  `site/built/fig/` subdir. 
+
 # sandpaper 0.0.0.9008
 
 BUG FIX
+-------
 
 * files that were removed from the source are now also removed in the site/built
   directory. This fixes issue #47

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -130,7 +130,7 @@ build_episode_md <- function(path, hash, outdir = path_built(path),
       class.error   = "error",
       class.warning = "warning",
       class.message = "output",
-      fig.path      = fs::path("fig", paste0(slug, "-"))
+      fig.path      = fs::path("fig", paste0(slug, "-rendered-"))
     )
 
     # Set the working directory -----------------------------

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -39,11 +39,3 @@ get_artifacts <- function(path, subfolder = "episodes") {
   )
 }
 
-get_figs <- function(path, slug) {
-  fs::path_abs(
-    fs::dir_ls(
-      path = fs::path(path_built(path), "fig"),
-      regexp = paste0(slug, "-", "*")
-    )
-  )
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -232,6 +232,16 @@ get_build_status <- function(sources, built, rebuild = FALSE) {
   list(build = to_be_built, remove = to_be_removed)
 }
 
+get_figs <- function(path, slug) {
+  fs::path_abs(
+    fs::dir_ls(
+      path = fs::path(path_built(path), "fig"),
+      regexp = paste0(slug, "-rendered-"),
+      fixed = TRUE
+    )
+  )
+}
+
 check_order <- function(order, what) {
   if (is.null(order)) {
     stop(paste(what, "must have an order"), call. = FALSE)

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -8,6 +8,14 @@ test_that("markdown sources can be built without fail", {
   expect_false(fs::dir_exists(tmp))
   res <- create_lesson(tmp)
   create_episode("second-episode", path = tmp)
+  writeLines(c(
+    "---",
+    "title: Pyramid",
+    "---",
+    "One of the best albums by MJQ"
+   ),
+    con = fs::path(tmp, "instructors", "pyramid.md")
+  )
   expect_warning(s <- get_episodes(tmp), "set_episodes")
   set_episodes(tmp, s, write = TRUE)
   expect_equal(res, tmp, ignore_attr = TRUE)
@@ -34,14 +42,20 @@ test_that("markdown sources can be built without fail", {
     # Folders
     "data", 
     "fig",
-    "files"
+    "files",
+    "pyramid.md"
   )
   a <- fs::dir_ls(fs::path(tmp, "site", "built"))
   expect_equal(fs::path_file(a), b)
   b <- c(
-    b[seq(length(s) + 3)], # Files without folders
+    # Generated markdown files
+    fs::path_ext_set(s, "md"), 
+    "CODE_OF_CONDUCT.md", 
+    "LICENSE.md", 
+    "Setup.md", 
     # Generated figures
-    paste0(fs::path_ext_remove(s), "-pyramid-1.png")
+    paste0(fs::path_ext_remove(s), "-rendered-pyramid-1.png"),
+    "pyramid.md"
   )
   a <- fs::dir_ls(fs::path(tmp, "site", "built"), recurse = TRUE, type = "file")
   expect_equal(fs::path_file(a), b)
@@ -68,16 +82,31 @@ test_that("markdown sources can be built without fail", {
 
   # Removing files will result in the markdown files being removed
   e2 <- fs::path(res, "episodes", "02-second-episode.Rmd")
+  built_path <- path_built(res)
   fs::file_delete(e2)
   reset_episodes(res)
   set_episodes(res, "01-introduction.Rmd", write = TRUE)
   build_markdown(res)
   h1 <- expect_hashed(res, "01-introduction.Rmd")
   expect_length(get_figs(res, "01-introduction"), 1)
+
   # The second episode should not exist
   expect_false(fs::file_exists(e2))
-  expect_false(fs::file_exists(fs::path(res, "built", "02-second-episode.md")))
+  expect_false(fs::file_exists(fs::path(built_path, "02-second-episode.md")))
   # The figures for the second episode should not exist either
   expect_length(get_figs(res, "02-second-episode"), 0)
+  
+  # Removing files with sub-slugs will not have side-effects
+  fs::file_delete(fs::path(res, "instructors", "pyramid.md"))
+  build_markdown(res)
+  h1 <- expect_hashed(res, "01-introduction.Rmd")
+  expect_length(get_figs(res, "01-introduction"), 1)
+
+  # The deleted file should be properly removed
+  expect_false(fs::file_exists(fs::path(built_path, "pyramid.md")))
+
+  # The image should still exist
+  pyramid_fig <- fs::path(built_path, "fig", "01-introduction-rendered-pyramid-1.png")
+  expect_true(fs::file_exists(pyramid_fig))
   
 })


### PR DESCRIPTION
Once again in the saga of "Zhian has not thought out this caching mechanism properly" we find ourselves at a junction where we are fixing bugs that were introduced by fixing other bugs.

### Summary

 - `get_figs()` now does a fixed search instead of regex to avoid the situation where a slug would do a partial match
 - `build_episode_md()` now specifies that the figures should have the prefix of `{SLUG}-rendered-`, which should help reduce partial matching snafus

This will fix #49
