### PR TITLE
update DESCRIPTION to use official drat repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,8 +36,8 @@ Suggests:
     covr,
     withr,
     jsonlite,
-    varnish (>= 0.0.0.9001)
-Additional_repositories: https://zkamvar.github.io/drat/
+    varnish (>= 0.0.0.9002)
+Additional_repositories: https://carpentries.github.io/drat/
 Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3


### PR DESCRIPTION
This simply changes the additional repository to be the carpentries drat