### PR TITLE
kill rendered HTML

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,15 @@
 NEW FEATURES
 ------------
 
-* In RStudio, the **knit button works** :tada:
+* In RStudio, the **knit button works** :tada: (fix #77; @zkamvar, #82)
 * `sandpaper_site()` is a site generator function that allows {rmarkdown} to
   use the {sandpaper} machinery to build the site from
   `rmarkdown::render_site()`
 * `build_site()` gains a `slug` argument that tailors the previewed content.
 * `create_lesson()` will now create a blank `index.md` with `site:
   sandpaper_site` as the only YAML item. 
+* HTML accidentally rendered to the source directories are silently removed
+  when the site is built. (fix #78, @zkamvar, #84)
 
 # sandpaper 0.0.0.9012
 

--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -31,8 +31,16 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
     license  = fs::path(root_path(path), "LICENSE.md"),
     NULL
   )
+  
+
   sources <- unlist(source_list, use.names = FALSE)
   names(sources) <- get_slug(sources)
+
+  # If the user accidentally used rmarkdown::render(), then they would end up
+  # with an html artifact in here and it will clog up the machinery. Best to 
+  # remove it at the source.
+  remove_rendered_html(sources)
+
   built          <- get_markdown_files()
   if (length(built)) names(built) <- get_slug(built)
 
@@ -90,6 +98,14 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
 }
 
 
+
+remove_rendered_html <- function(episodes) {
+  htmls <- fs::path_ext_set(episodes, "html")
+  exists <- fs::file_exists(htmls)
+  if (any(exists)) {
+    fs::file_delete(htmls[exists])
+  }
+}
 
 
 


### PR DESCRIPTION
This will fix #78 by silently deleting rendered html in the source files.