### PR TITLE
Require pandoc >= 2.11

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@master
         with:
-          pandoc-version: '2.10' # NOTE: we need to add version catches for the tests.
+          pandoc-version: '2.11' # NOTE: we need to add version catches for the tests.
 
       - name: Query dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9016
+Version: 0.0.0.9017
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9017
+
+ENGINE UPDATE
+-------------
+
+* The version of pandoc will be explicitly checked to ensure that the version
+  used is at least 2.10.
+
 # sandpaper 0.0.0.9016
 
 BUG FIX

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ ENGINE UPDATE
 -------------
 
 * The version of pandoc will be explicitly checked to ensure that the version
-  used is at least 2.10.
+  used is at least 2.11.
 
 # sandpaper 0.0.0.9016
 

--- a/R/build_lesson.R
+++ b/R/build_lesson.R
@@ -27,7 +27,8 @@
 #' build_lesson(tmp)
 build_lesson <- function(path = ".", rebuild = FALSE, quiet = !interactive(), preview = TRUE, override = list()) {
 
-  # step 0: build_lesson defaults to a local build
+  # step 0: check pandoc installation; build_lesson defaults to a local build
+  check_pandoc()
   slug <- if (fs::is_file(path)) get_slug(path) else NULL
   path <- set_source_path(path)
   on.exit(reset_build_paths())

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -10,6 +10,8 @@
 #'   right page. 
 #' @keywords internal
 build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, override = list(), slug = NULL) {
+  # step 1: check pandoc
+  check_pandoc(quiet)
   # step 2: build the package site
   pkg <- pkgdown::as_pkgdown(path_site(path), override = override)
   built_path <- fs::path(pkg$src_path, "built")

--- a/R/utils.R
+++ b/R/utils.R
@@ -242,3 +242,22 @@ gitignore_items <- function() {
   delayedAssign("GITIGNORED", gitignore_items(), eval.env = ns, assign.env = ns)
 }
 #nocov end
+
+check_pandoc <- function(quiet = TRUE) {
+  pan <- rmarkdown::find_pandoc()
+  if (rmarkdown::pandoc_available("2.11")) {
+    if (!quiet) {
+      message("pandoc found")
+      message("version : ", pan$version)
+      message("path    : ", shQuote(pan$dir))
+    }
+  } else {
+    msg <- "{sandpaper} requires pandoc version 2.11 or higher"
+    if (pan$version == 0) {
+      msg <- paste(msg, "\nplease use RStudio or visit <https://pandoc.org/installing.html> to install")
+    } else {
+      msg <- paste(msg, "\nYou have version", pan$version, "in", shQuote(pan$dir))
+    }
+    stop(msg, call. = FALSE)
+  }
+}


### PR DESCRIPTION
There will be situations where the user does not have the correct version of pandoc installed (likely from an old RStudio version or CLI), so this function will report if the version is incorrect.