### PR TITLE
Fix extension error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9021
+Version: 0.0.0.9022
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# sandpaper 0.0.0.9022
+
+BUG FIX
+-------
+
+* `build_markdown(rebuild = TRUE)` now actually rebuilds the lesson
+* Changing an episode suffix will no longer result in a build error. This was
+  due to `build_markdown()` trying to clean _after_ building the output instead
+  of before. It's a situation of throwing the baby out with the bathwater. In
+  any case, this fixes #102.
+
 # sandpaper 0.0.0.9021
 
 BUG FIX

--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -19,7 +19,7 @@
 build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
 
   episode_path <- path_episodes(path)
-  outdir       <- path_built()
+  outdir       <- path_built(path)
 
   # Determine build status for the episodes ------------------------------------
   source_list    <- get_resource_list(path)
@@ -51,16 +51,6 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
     copy_assets(f, outdir)
   }
 
-  # Render the episode files to the built directory ----------------------------
-  for (i in seq_along(db$build)) {
-    build_episode_md(
-      path    = db$build[i],
-      outdir  = outdir,
-      workdir = outdir,
-      quiet   = quiet
-    )
-  }
-
   # Remove detritus ------------------------------------------------------------
   remove <- db$remove
   if (length(remove)) {
@@ -72,6 +62,17 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
       if (length(figs)) fs::file_delete(figs)
     }
   }
+
+  # Render the episode files to the built directory ----------------------------
+  for (i in seq_along(db$build)) {
+    build_episode_md(
+      path    = db$build[i],
+      outdir  = outdir,
+      workdir = outdir,
+      quiet   = quiet
+    )
+  }
+
 
   # Update metadata ------------------------------------------------------------
   if (length(db$build) > 0) {

--- a/R/utils-built-db.R
+++ b/R/utils-built-db.R
@@ -76,9 +76,13 @@ build_status <- function(sources, db = "site/built/md5sum.txt", rebuild = FALSE,
   # merge destroys the order, so we need to reset it. Consequently, it will
   # also remove the files that no longer exist in the sources list.
   one <- one[match(sources, one$file), , drop = FALSE]
-  # exclude files if checksums are not changed
-  unchanged <- one[[newsum]] == one[[oldsum]]
-  files = setdiff(sources, one[['file']][unchanged])
+  if (rebuild) {
+    files = one[['file']]
+  } else {
+    # exclude files if checksums are not changed
+    unchanged <- one[[newsum]] == one[[oldsum]]
+    files = setdiff(sources, one[['file']][unchanged])
+  }
   if (write) 
     write_build_db(one[, 1:3], db)
   list(

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -51,6 +51,27 @@ test_that("markdown sources can be rebuilt without fail", {
   })
 })
 
+test_that("modifying a file suffix will force the file to be rebuilt", {
+  
+  # If we change a markdown file to an Rmarkdown file, it should rebuild that
+  # file
+  instruct <- fs::path(tmp, "instructors", "pyramid.md")
+  fs::file_move(instruct, fs::path_ext_set(instruct, "Rmd"))
+  withr::defer({
+    # clean up: reset file and rebuild
+    fs::file_move(fs::path_ext_set(instruct, "Rmd"), instruct)
+    build_markdown(res, quiet = TRUE)
+  })
+
+  # Test that the birth times are changed.
+  old_info <- fs::file_info(fs::path(tmp, "site", "built", "pyramid.md"))
+  suppressMessages({
+    build_markdown(res, quiet = TRUE)
+  })
+  new_info <- fs::file_info(fs::path(tmp, "site", "built", "pyramid.md"))
+  expect_gt(new_info$birth_time, old_info$birth_time)
+})
+
 test_that("Artifacts are accounted for", {
 
   s <- get_episodes(tmp)

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -13,7 +13,7 @@ test_that("markdown sources can be built without fail", {
   writeLines(c(
     "---",
     "title: Pyramid",
-    "---",
+    "---\n",
     "One of the best albums by MJQ"
    ),
     con = instruct
@@ -37,6 +37,18 @@ test_that("markdown sources can be built without fail", {
   # # Accidentaly rendered HTML is removed before building
   expect_false(fs::file_exists(fs::path_ext_set(instruct, "html")))
   
+})
+
+
+test_that("markdown sources can be rebuilt without fail", {
+  
+  # no building needed
+  expect_silent(build_markdown(res, quiet = FALSE))
+  
+  # everything rebuilt
+  suppressMessages({
+  expect_output(build_markdown(res, quiet = FALSE, rebuild = TRUE), "ordinary text without R code")
+  })
 })
 
 test_that("Artifacts are accounted for", {


### PR DESCRIPTION
This allows maintainers to change the extension of the source files without error, which will fix #102 