### PR TITLE
Enforce main branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
+          remotes::install_github("ropensci/tinkr")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     commonmark,
     xml2,
     fs,
+    gh,
     gert (>= 1.0.1),
     rstudioapi,
     rlang (>= 0.4.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9023
+Version: 0.0.0.9024
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# sandpaper 0.0.0.9024
+
+BUG FIX
+-------
+
+ * `create_lesson()` will now enforce "main" or the default branch (if 
+   init.defaultBranch is set) as the default branch for the new lesson. It will
+   also try to make the URL match the project name and user name (but the latter
+   is limited to users who have GitHub PAT set up that {gh} recognises).
+
 # sandpaper 0.0.0.9023
 
 BUG FIX

--- a/R/create_lesson.R
+++ b/R/create_lesson.R
@@ -36,14 +36,16 @@ create_lesson <- function(path, name = fs::path_file(path), rstudio = rstudioapi
   copy_template("index", path, "index.md")
   copy_template("placeholder", fs::path(path, "instructors"), "instructor-notes.md")
   copy_template("placeholder", fs::path(path, "profiles"), "learner-profiles.md")
+
+  account <- tryCatch(gh::gh_whoami()$login, error = function(e) "carpentries")
   copy_template("config", path, "config.yaml",
     values = list(
       title      = "Lesson Title",
       carpentry  = "cp",
       life_cycle = "pre-alpha",
       license    = "CC-BY 4.0",
-      source     = "https://github.com/carpentries/sandpaper",
-      branch     = "main",
+      source     = glue::glue("https://github.com/{account}/{basename(path)}"),
+      branch     = get_default_branch(),
       contact    = "team@carpentries.org",
       NULL
     )
@@ -66,6 +68,7 @@ create_lesson <- function(path, name = fs::path_file(path), rstudio = rstudioapi
 
   gert::git_add(".", repo = path)
   gert::git_commit(message = "Initial commit [via {sandpaper}]", repo = path)
+  enforce_main_branch(path)
   reset_git_user(path)
   
   if (open) {

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -13,6 +13,11 @@ test_that("lessons can be created in empty directories", {
   tmp <- normalizePath(tmp)
   expect_false(wd == fs::path(normalizePath(getwd())))
   expect_equal(normalizePath(getwd()), tmp)
+  # enforce that we do NOT have a master branch
+  expect_false(gert::git_branch(tmp) == "master")
+  expect_false(gert::git_branch_exists("master", repo = tmp))
+  # enforce that our new branch matches the user's default branch (or main)
+  expect_true(gert::git_branch(tmp) == sandpaper:::get_default_branch())
 
   # Make sure everything exists
   expect_true(check_lesson(tmp))


### PR DESCRIPTION
`create_lesson()` will now enforce "main" or the default branch (if init.defaultBranch is set) as the default branch for the new lesson. It will also try to make the URL match the project name and user name (but the latter is limited to users who have GitHub PAT set up that {gh} recognises).

This fixes #117 

A demonstration that this works:

``` r
tmp <- tempfile(pattern = "willow")
sandpaper::create_lesson(tmp, open = FALSE)
#> [1] "/tmp/RtmpVHbNdT/willow21a2c5272ca6c"
sandpaper::get_config(tmp)[c("source", "branch")] # repository set to my config
#> $source
#> [1] "https://github.com/zkamvar/willow21a2c5272ca6c"
#> 
#> $branch
#> [1] "main"
gert::libgit2_config() # libgit2 is not sufficient to recognise default branch
#> $version
#> [1] '0.28.4'
#> 
#> $ssh
#> [1] TRUE
#> 
#> $https
#> [1] TRUE
#> 
#> $threads
#> [1] TRUE
#> 
#> $config.global
#> [1] "/home/zhian/.gitconfig"
#> 
#> $config.system
#> [1] ""
#> 
#> $config.home
#> [1] "/home/zhian"
gert::git_info(tmp)    # main is set as default
#> $path
#> [1] "/tmp/RtmpVHbNdT/willow21a2c5272ca6c/"
#> 
#> $bare
#> [1] FALSE
#> 
#> $head
#> [1] "refs/heads/main"
#> 
#> $shorthand
#> [1] "main"
#> 
#> $commit
#> [1] "8bc3456c328ae69907aff95f34de07a2c5dc2e75"
#> 
#> $remote
#> [1] NA
#> 
#> $upstream
#> [1] NA
#> 
#> $reflist
#> [1] "refs/heads/main"
```

<sup>Created on 2021-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>