### PR TITLE
Bump versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9024
+Version: 0.0.0.9025
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,20 +27,20 @@ Imports:
     rmarkdown (>= 2.4),
     rprojroot,
     usethis (>= 2.0.0),
-    utils,
-    tools,
     whisker,
-    callr
+    callr,
+    utils,
+    tools
 Suggests: 
     testthat (>= 3.0.0),
     cli (>= 2.0.2),
     covr,
     withr,
     jsonlite,
+    renv (>= 0.13.2),
+    sessioninfo,
     varnish (>= 0.0.0.9002)
 Additional_repositories: https://carpentries.github.io/drat/
-Remotes:
-  ropensci/tinkr
 Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Boilerplate directory structure, build tools, and hosting tools for
 License: MIT + file LICENSE
 Imports: 
     pkgdown (>= 1.6.0),
-    pegboard (>= 0.0.0.9012),
+    pegboard (>= 0.0.0.9014),
     commonmark,
     xml2,
     fs,
@@ -39,6 +39,8 @@ Suggests:
     jsonlite,
     varnish (>= 0.0.0.9002)
 Additional_repositories: https://carpentries.github.io/drat/
+Remotes:
+  ropensci/tinkr
 Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9025
+
+DEPENDENCY UPDATE
+-----------------
+
+ * required {pegboard} has been bumped to version 0.0.0.9014
+ * {renv} and {sessioninfo} added to Suggested packages.
+
 # sandpaper 0.0.0.9024
 
 BUG FIX


### PR DESCRIPTION
This simply bumps the version of the dependent packages (because I forgot to do it in a previous update).