### PR TITLE
Fix header levels

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,14 +21,13 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release', cov: 'true'}
-          # - {os: windows-latest, r: 'release'}
-          # - {os: windows-latest, r: '3.6'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          # - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -54,7 +53,7 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Restore package cache
         if: runner.os != 'Windows'
         uses: actions/cache@v1
         with:
@@ -78,7 +77,6 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_github("ropensci/tinkr")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "16.04"), sep = "\n")')
-          sudo apt install libgit2-dev
+          sudo apt install libgit2-dev libxslt1-dev
 
       - name: Install dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9025
+Version: 0.0.0.9026
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -39,7 +39,7 @@ Suggests:
     jsonlite,
     renv (>= 0.13.2),
     sessioninfo,
-    varnish (>= 0.0.0.9002)
+    varnish (>= 0.0.0.9005)
 Additional_repositories: https://carpentries.github.io/drat/
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# sandpaper 0.0.0.9026
+
+MISC
+----
+
+* callout blocks with headers greater than h3 are now rendered properly and no
+  longer forced to h3
+* tests now clean up after themselves and no longer change the working directory
+  by default
+* {varnish} version bumped
+
 # sandpaper 0.0.0.9025
 
 DEPENDENCY UPDATE

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,10 @@ MISC
   longer forced to h3
 * tests now clean up after themselves and no longer change the working directory
   by default
-* {varnish} version bumped
+* {varnish} version bumped to 0.0.0.9005
+* tests that require pandoc will be skipped if pandoc is not available
+* tests for the presences of multiple files will use setequal instead of equal
+  to allow for alternate sorting orders. 
 
 # sandpaper 0.0.0.9025
 

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -24,7 +24,10 @@
 #' tmp <- tempfile()
 #' create_lesson(tmp, open = FALSE)
 #' suppressWarnings(set_episodes(tmp, get_episodes(tmp), write = TRUE))
-#' build_lesson(tmp)
+#' if (rmarkdown::pandoc_available("2.11")) {
+#'   # we can only build this if we have pandoc
+#'   build_lesson(tmp)
+#' }
 #' 
 #' # create a new file in extras
 #' fun_file <- file.path(tmp, "episodes", "files", "fun.Rmd")

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -38,9 +38,12 @@
 #' writeLines(txt, fun_file)
 #' hash <- tools::md5sum(fun_file)
 #' res <- build_episode_md(fun_file, hash)
-#' build_episode_html(res, path_src = fun_file, 
-#'   pkg = pkgdown::as_pkgdown(file.path(tmp, "site"))
-#' )
+#' if (rmarkdown::pandoc_available("2.11")) {
+#'   # we can only build this if we have pandoc
+#'   build_episode_html(res, path_src = fun_file, 
+#'     pkg = pkgdown::as_pkgdown(file.path(tmp, "site"))
+#'   )
+#' }
 build_episode_html <- function(path_md, path_src = NULL, 
                                page_back = "index.md", page_forward = "index.md", 
                                pkg, quiet = FALSE) {

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -31,7 +31,8 @@
 #' txt <- c(
 #'  "---\ntitle: Fun times\n---\n\n",
 #'  "# new page\n", 
-#'  "This is coming from `r R.version.string`"
+#'  "This is coming from `r R.version.string`\n",
+#'  "::: testimonial\n\n#### testimony!\n\nwhat\n:::\n"
 #' )
 #' file.create(fun_file)
 #' writeLines(txt, fun_file)

--- a/R/build_lesson.R
+++ b/R/build_lesson.R
@@ -24,7 +24,8 @@
 #' create_lesson(tmp, open = FALSE)
 #' create_episode("first-script", path = tmp)
 #' check_lesson(tmp)
-#' build_lesson(tmp)
+#' if (rmarkdown::pandoc_available())
+#'   build_lesson(tmp)
 build_lesson <- function(path = ".", rebuild = FALSE, quiet = !interactive(), preview = TRUE, override = list()) {
 
   # step 0: check pandoc installation; build_lesson defaults to a local build

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -15,6 +15,7 @@
 #' @keywords internal
 #' @examples
 #'
+#' if (rmarkdown::pandoc_available("2.11")) {
 #' # first example---markdown to HTML
 #' tmp <- tempfile()
 #' ex <- c("# Markdown", 
@@ -39,6 +40,7 @@
 #' writeLines(lu, lua)
 #' lf <- paste0("--lua-filter=", lua)
 #' cat(sandpaper:::render_html(tmp, lf))
+#' }
 render_html <- function(path_in, ..., quiet = FALSE) {
   htm <- tempfile(fileext = ".html")
   on.exit(unlink(htm), add = TRUE)

--- a/R/reset_site.R
+++ b/R/reset_site.R
@@ -8,7 +8,8 @@
 #' @examples
 #' tmp <- tempfile()
 #' create_lesson(tmp)
-#' build_lesson(tmp, preview = FALSE)
+#' if (rmarkdown::pandoc_available("2.11"))
+#'   build_lesson(tmp, preview = FALSE)
 #' dir(file.path(tmp, "site"))
 #' reset_site(tmp)
 #' dir(file.path(tmp, "site"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,7 +69,8 @@ enforce_main_branch <- function(path) {
 get_default_branch <- function() {
   cfg <- gert::git_config_global()
   default <- cfg$value[cfg$name == "init.defaultbranch"]
-  if (length(default) == 0) "main" else default
+  invalid <- length(default) == 0 || default == "master"
+  if (invalid) "main" else default
 }
 
 # This checks if we have set a temporary git user and then unsets it. It will 

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -193,8 +193,8 @@ function level_head(el, level)
     el.content:remove(id)
   end
 
-  if header ~= level then
-    -- force the header level to be 2
+  if header.level ~= nil and header.level < level then
+    -- force the header level to increase
     el.content[id].level = level
   end
 
@@ -229,7 +229,7 @@ handle_our_divs = function(el)
   -- Instructor notes should be aside tags
   v,i = el.classes:find("instructor")
   if i ~= nil then
-    level_head(el, 3) -- force level to be 3
+    level_head(el, 3) -- force level to be at most 3
     return step_aside(el, i) -- create aside padding
   end
 
@@ -254,11 +254,19 @@ handle_our_divs = function(el)
   --
   v,i = el.classes:find("callout")
   if i ~= nil then
-    level_head(el, 3) -- force level to be 3
+    level_head(el, 3) -- force level to be at most 3
     return step_aside(el, i) -- create aside padding
   end
 
-  -- All other Div tags should have level 2 headers
+  -- When I finally know how to manipulate jquery, I can implement this, but
+  -- for now, they will remain at level 2 :(
+  -- v,i = el.classes:find("solution")
+  -- if i ~= nil then
+  --   level_head(el, 3) -- force level to be at most 3
+  --   return el
+  -- end
+
+  -- All other Div tags should have at most level 2 headers
   level_head(el, 2)
 
   return el

--- a/man/build_episode_html.Rd
+++ b/man/build_episode_html.Rd
@@ -52,7 +52,8 @@ fun_file <- file.path(tmp, "episodes", "files", "fun.Rmd")
 txt <- c(
  "---\ntitle: Fun times\n---\n\n",
  "# new page\n", 
- "This is coming from `r R.version.string`"
+ "This is coming from `r R.version.string`\n",
+ "::: testimonial\n\n#### testimony!\n\nwhat\n:::\n"
 )
 file.create(fun_file)
 writeLines(txt, fun_file)

--- a/man/build_episode_html.Rd
+++ b/man/build_episode_html.Rd
@@ -45,7 +45,10 @@ they are doing.
 tmp <- tempfile()
 create_lesson(tmp, open = FALSE)
 suppressWarnings(set_episodes(tmp, get_episodes(tmp), write = TRUE))
-build_lesson(tmp)
+if (rmarkdown::pandoc_available("2.11")) {
+  # we can only build this if we have pandoc
+  build_lesson(tmp)
+}
 
 # create a new file in extras
 fun_file <- file.path(tmp, "episodes", "files", "fun.Rmd")

--- a/man/build_episode_html.Rd
+++ b/man/build_episode_html.Rd
@@ -59,9 +59,12 @@ file.create(fun_file)
 writeLines(txt, fun_file)
 hash <- tools::md5sum(fun_file)
 res <- build_episode_md(fun_file, hash)
-build_episode_html(res, path_src = fun_file, 
-  pkg = pkgdown::as_pkgdown(file.path(tmp, "site"))
-)
+if (rmarkdown::pandoc_available("2.11")) {
+  # we can only build this if we have pandoc
+  build_episode_html(res, path_src = fun_file, 
+    pkg = pkgdown::as_pkgdown(file.path(tmp, "site"))
+  )
+}
 }
 \seealso{
 \code{\link[=build_episode_md]{build_episode_md()}}, \code{\link[=build_lesson]{build_lesson()}}, \code{\link[=build_markdown]{build_markdown()}}, \code{\link[=render_html]{render_html()}}

--- a/man/build_lesson.Rd
+++ b/man/build_lesson.Rd
@@ -41,5 +41,6 @@ tmp <- tempfile()
 create_lesson(tmp, open = FALSE)
 create_episode("first-script", path = tmp)
 check_lesson(tmp)
-build_lesson(tmp)
+if (rmarkdown::pandoc_available())
+  build_lesson(tmp)
 }

--- a/man/render_html.Rd
+++ b/man/render_html.Rd
@@ -25,6 +25,7 @@ Carpentries such as \code{markdown_in_html_blocks}, \code{tex_math_dollars}, and
 }
 \examples{
 
+if (rmarkdown::pandoc_available("2.11")) {
 # first example---markdown to HTML
 tmp <- tempfile()
 ex <- c("# Markdown", 
@@ -49,5 +50,6 @@ lu <- c("Str = function (elem)",
 writeLines(lu, lua)
 lf <- paste0("--lua-filter=", lua)
 cat(sandpaper:::render_html(tmp, lf))
+}
 }
 \keyword{internal}

--- a/man/reset_site.Rd
+++ b/man/reset_site.Rd
@@ -15,7 +15,8 @@ Use this if you want to rebuild your site from scratch.
 \examples{
 tmp <- tempfile()
 create_lesson(tmp)
-build_lesson(tmp, preview = FALSE)
+if (rmarkdown::pandoc_available("2.11"))
+  build_lesson(tmp, preview = FALSE)
 dir(file.path(tmp, "site"))
 reset_site(tmp)
 dir(file.path(tmp, "site"))

--- a/tests/testthat/test-build_episode.R
+++ b/tests/testthat/test-build_episode.R
@@ -35,6 +35,7 @@ test_that("build_episode_html() works independently", {
   expect_output(pkgdown::init_site(pkg))
   
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   # create a new file in extras
   fun_file <- file.path(tmp, "episodes", "files", "fun.Rmd")
   txt <- c(

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -6,7 +6,7 @@ test_that("lessons can be built sanely", {
 
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
   create_episode("second-episode", path = tmp)
   expect_warning(s <- get_episodes(tmp), "set_episodes")
   set_episodes(tmp, s, write = TRUE)
@@ -14,7 +14,7 @@ test_that("lessons can be built sanely", {
 
   # It's noisy at first
   suppressMessages({
-  expect_output(build_lesson(res, preview = FALSE, quiet = FALSE), "ordinary text without R code")
+    expect_output(build_lesson(res, preview = FALSE, quiet = FALSE), "ordinary text without R code")
   })
 
   # see helper-hash.R
@@ -74,7 +74,7 @@ test_that("episodes with HTML in the title are rendered correctly", {
 
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
   create_episode("second-episode", path = tmp)
   expect_warning(s <- get_episodes(tmp), "set_episodes")
   set_episodes(tmp, s, write = TRUE)

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -12,6 +12,8 @@ test_that("lessons can be built sanely", {
   set_episodes(tmp, s, write = TRUE)
   expect_equal(res, tmp, ignore_attr = TRUE)
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
   # It's noisy at first
   suppressMessages({
     expect_output(build_lesson(res, preview = FALSE, quiet = FALSE), "ordinary text without R code")
@@ -79,6 +81,8 @@ test_that("episodes with HTML in the title are rendered correctly", {
   expect_warning(s <- get_episodes(tmp), "set_episodes")
   set_episodes(tmp, s, write = TRUE)
   expect_equal(res, tmp, ignore_attr = TRUE)
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
 
   se <- readLines(fs::path(tmp, "episodes", "02-second-episode.Rmd"))
   se[[2]] <- "title: A **bold** title"

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -7,7 +7,7 @@ withr::defer(fs::dir_delete(tmp))
 test_that("markdown sources can be built without fail", {
   
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
   create_episode("second-episode", path = tmp)
   instruct <- fs::path(tmp, "instructors", "pyramid.md")
   writeLines(c(

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -44,6 +44,7 @@ test_that("markdown sources can be built without fail", {
 test_that("markdown sources can be rebuilt without fail", {
   
   # no building needed
+  skip_on_os("windows")
   expect_silent(build_markdown(res, quiet = FALSE))
   
   # everything rebuilt

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -25,6 +25,7 @@ test_that("markdown sources can be built without fail", {
   e <- fs::dir_ls(fs::path(tmp, "episodes"), recurse = TRUE, type = "file")
   expect_equal(fs::path_file(e), s)
 
+  skip_if_not(rmarkdown::pandoc_available("1.12.3"))
   # Accidentally rendered html live in their parent folders
   rmarkdown::render(instruct, quiet = TRUE)
   expect_true(fs::file_exists(fs::path_ext_set(instruct, "html"))) 

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -72,6 +72,7 @@ test_that("modifying a file suffix will force the file to be rebuilt", {
   })
 
   # Test that the birth times are changed.
+  skip_on_os("windows")
   old_info <- fs::file_info(fs::path(tmp, "site", "built", "pyramid.md"))
   suppressMessages({
     build_markdown(res, quiet = TRUE)

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -103,7 +103,7 @@ test_that("Artifacts are accounted for", {
     "pyramid.md"
   )
   a <- fs::dir_ls(fs::path(tmp, "site", "built"))
-  expect_equal(fs::path_file(a), b)
+  expect_setequal(fs::path_file(a), b)
   b <- c(
     # Generated markdown files
     fs::path_ext_set(s, "md"), 
@@ -119,7 +119,7 @@ test_that("Artifacts are accounted for", {
     "pyramid.md"
   )
   a <- fs::dir_ls(fs::path(tmp, "site", "built"), recurse = TRUE, type = "file")
-  expect_equal(fs::path_file(a), b)
+  expect_setequal(fs::path_file(a), b)
 
 })
 

--- a/tests/testthat/test-clear_site.R
+++ b/tests/testthat/test-clear_site.R
@@ -21,6 +21,7 @@ test_that("the site can be cleared", {
   # I can save a file in the episodes directory and it will be propogated 
   saveRDS(expected, file = fs::path(tmp, "episodes", "data", "test.rds"))
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   build_lesson(tmp, preview = FALSE, quiet = TRUE)
 
   built_site <- fs::dir_ls(fs::path(tmp, "site"))

--- a/tests/testthat/test-clear_site.R
+++ b/tests/testthat/test-clear_site.R
@@ -6,7 +6,7 @@ test_that("the site can be cleared", {
 
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
   expect_warning(s <- get_episodes(tmp), "set_episodes")
   set_episodes(tmp, s, write = TRUE)
 

--- a/tests/testthat/test-create_episode.R
+++ b/tests/testthat/test-create_episode.R
@@ -4,7 +4,7 @@ tmp    <- fs::path(tmpdir, "lesson-example")
 
 withr::defer(fs::dir_delete(tmp))
 expect_false(fs::dir_exists(tmp))
-res <- create_lesson(tmp)
+res <- create_lesson(tmp, open = FALSE)
 
 test_that("prefixed episodes can be created", {
 

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -7,6 +7,7 @@ test_that("lessons can be created in empty directories", {
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
   wd  <- fs::path(normalizePath(getwd()))
+  withr::defer(setwd(wd))
   suppressMessages({expect_message({
     res <- create_lesson(tmp, rstudio = TRUE, open = TRUE)
   }, "Setting active project to")})
@@ -106,12 +107,12 @@ test_that("lessons cannot be created in directories that are occupied", {
 
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
 
   # Make sure everything exists
   expect_true(fs::dir_exists(tmp))
 
   # This should fail
-  expect_error(create_lesson(tmp), "lesson-example is not an empty directory.")
+  expect_error(create_lesson(tmp, open = FALSE), "lesson-example is not an empty directory.")
 
 })

--- a/tests/testthat/test-fetch_workflows.R
+++ b/tests/testthat/test-fetch_workflows.R
@@ -8,14 +8,14 @@ test_that("github workflows can be fetched", {
 
   skip_if_offline()
   # default a bare git repo
-  expect_equal(ls_file(tmp), ".git")
+  expect_setequal(ls_file(tmp), ".git")
   
   suppressMessages({
     fetch_github_workflows(tmp, "sandpaper-main.yaml")
   })
 
-  expect_equal(ls_file(tmp), c(".Rbuildignore", ".git", ".github"))
-  expect_equal(
+  expect_setequal(ls_file(tmp), c(".Rbuildignore", ".git", ".github"))
+  expect_setequal(
     ls_file(fs::path(tmp, ".github", "workflows")), 
     "sandpaper-main.yaml"
   )
@@ -48,9 +48,9 @@ test_that("github workflows can be added", {
 
   files_we_need <- eval(formals(fetch_github_workflows)$files)
 
-  expect_equal(
+  expect_setequal(
     ls_file(fs::path(tmp, ".github", "workflows")), 
-    sort(files_we_need)
+    files_we_need
   )
 
 })

--- a/tests/testthat/test-format_syllabus.R
+++ b/tests/testthat/test-format_syllabus.R
@@ -6,6 +6,7 @@ withr::defer(fs::dir_delete(tmp))
 
 test_that("the formatted syllabus renders markdown", {
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   expect_false(fs::dir_exists(tmp))
   res <- create_lesson(tmp, open = FALSE, rstudio = FALSE)
   expect_warning(s <- get_episodes(tmp), "set_episodes")

--- a/tests/testthat/test-format_syllabus.R
+++ b/tests/testthat/test-format_syllabus.R
@@ -2,11 +2,17 @@ tmpdir <- fs::file_temp()
 fs::dir_create(tmpdir)
 tmp    <- fs::path(tmpdir, "lesson-example")
 
-withr::defer(fs::dir_delete(tmp))
+withr::defer({
+  if (fs::is_dir(tmp))
+    fs::dir_delete(tmp)
+  else
+    fs::file_delete(tmp)
+})
 
 test_that("the formatted syllabus renders markdown", {
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
+  
   expect_false(fs::dir_exists(tmp))
   res <- create_lesson(tmp, open = FALSE, rstudio = FALSE)
   expect_warning(s <- get_episodes(tmp), "set_episodes")

--- a/tests/testthat/test-format_syllabus.R
+++ b/tests/testthat/test-format_syllabus.R
@@ -6,7 +6,7 @@ withr::defer({
   if (fs::is_dir(tmp))
     fs::dir_delete(tmp)
   else
-    fs::file_delete(tmp)
+    fs::dir_delete(tmpdir)
 })
 
 test_that("the formatted syllabus renders markdown", {

--- a/tests/testthat/test-get_dropdown.R
+++ b/tests/testthat/test-get_dropdown.R
@@ -4,7 +4,7 @@ tmp    <- fs::path(tmpdir, "lesson-example")
 
 withr::defer(fs::dir_delete(tmp))
 expect_false(fs::dir_exists(tmp))
-res <- create_lesson(tmp)
+res <- create_lesson(tmp, open = FALSE)
 create_episode("outroduction", path = res)
 outro <- fs::path(res, "episodes", "02-outroduction.Rmd")
 fs::file_move(outro, fs::path_ext_set(outro, "md"))

--- a/tests/testthat/test-get_dropdown.R
+++ b/tests/testthat/test-get_dropdown.R
@@ -47,7 +47,7 @@ test_that("get_episodes() works in the right order", {
 test_that("get_learners() works as expected", {
 
   expected <- basename(as.character(fs::dir_ls(fs::path(tmp, "learners"))))
-  expect_equal(expected, c("Setup.md", basename(lt)))
+  expect_setequal(expected, c("Setup.md", basename(lt)))
 
   expect_silent(l <- get_learners(res))
   expect_equal(l, expected)

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -46,7 +46,7 @@ ex <- c("---",
 
 
 test_that("emoji are rendered", {
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   withr::local_file(tmp)
   writeLines("Emojis work :wink:", tmp)
@@ -54,7 +54,7 @@ test_that("emoji are rendered", {
 })
 
 test_that("links are auto rendered", {
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   withr::local_file(tmp)
   writeLines("Links work: https://carpentries.org/.", tmp)
@@ -62,7 +62,7 @@ test_that("links are auto rendered", {
 })
 
 test_that("footnotes are rendered", {
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   withr::local_file(tmp)
   writeLines("Footnotes work^[maybe they do?].", tmp)
@@ -76,7 +76,7 @@ test_that("footnotes are rendered", {
 
 test_that("pandoc structure is rendered correctly", {
   
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   out <- fs::file_temp()
   withr::local_file(tmp, out)
@@ -90,7 +90,7 @@ test_that("pandoc structure is rendered correctly", {
 
 test_that("paragraphs after objectives block are parsed correctly", {
   
-  skip_if_not(rmarkdown::pandoc_available("2.10"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   out <- fs::file_temp()
   withr::local_file(tmp, out)
@@ -105,15 +105,15 @@ test_that("paragraphs after objectives block are parsed correctly", {
 
 test_that("render_html applies the internal lua filter", {
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
   tmp <- fs::file_temp()
   withr::local_file(tmp)
 
   writeLines(ex, tmp)
   res <- render_html(tmp)
   
-  if (rmarkdown::pandoc_available("2.10")) {
-    expect_snapshot(cat(res))
-  }
+  expect_snapshot(cat(res))
 
   # Metadata blocks are parsed
   expect_match(res, "div class=\"row\"", fixed = TRUE)
@@ -140,6 +140,7 @@ test_that("render_html applies the internal lua filter", {
 
 test_that("render_html applies external lua filters", {
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   lua <- fs::file_temp()
   withr::local_file(tmp, lua)

--- a/tests/testthat/test-sandpaper_site.R
+++ b/tests/testthat/test-sandpaper_site.R
@@ -6,7 +6,7 @@ test_that("sandpaper_site produces a renderer", {
 
   withr::defer(fs::dir_delete(tmp))
   expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp)
+  res <- create_lesson(tmp, open = FALSE)
   withr::with_dir(tmp, res <- sandpaper_site())
   expect_type(res, "list")
   expect_named(res, c("name", "output_dir", "render", "clean", "subdirs"))

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -65,6 +65,9 @@ test_that("adding episodes will concatenate the schedule", {
   create_episode("second-episode", add = TRUE, path = tmp)
   expect_equal(res, tmp, ignore_attr = TRUE)
   expect_equal(get_episodes(tmp), c("01-introduction.Rmd", "03-second-episode.Rmd"))
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
   expect_silent(build_lesson(tmp, quiet = TRUE, preview = FALSE))
   yaml <- yaml::read_yaml(path_site_yaml(tmp))$navbar$left[[2L]]$menu
   expect_length(yaml, 2)
@@ -76,8 +79,12 @@ test_that("adding episodes will concatenate the schedule", {
 
 test_that("the schedule can be rearranged", {
 
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
   set_episodes(tmp, rev(get_episodes(tmp)), write = TRUE)
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
   expect_silent(build_lesson(tmp, quiet = TRUE, preview = FALSE))
   yaml <- yaml::read_yaml(path_site_yaml(tmp))$navbar$left[[2L]]$menu
   expect_length(yaml, 2)
@@ -99,6 +106,9 @@ test_that("the schedule can be truncated", {
 
   set_episodes(tmp, rev(get_episodes(tmp))[1], write = TRUE)
   expect_equal(get_episodes(tmp), "01-introduction.Rmd")
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
   expect_silent(build_lesson(tmp, quiet = TRUE, preview = FALSE))
   yaml <- yaml::read_yaml(path_site_yaml(tmp))$navbar$left[[2L]]$menu
   expect_length(yaml, 1)

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -79,7 +79,6 @@ test_that("adding episodes will concatenate the schedule", {
 
 test_that("the schedule can be rearranged", {
 
-  skip_if_not(rmarkdown::pandoc_available("2.11"))
   set_episodes(tmp, rev(get_episodes(tmp)), write = TRUE)
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
 


### PR DESCRIPTION
This updates the lua filters so that callout boxes can have headers that are above level three and still render (with the exception of challenge and solution boxes, since the latter are still hard-coded at the javascript level). 

When I first wrote the lua filters, I thought it would be a good idea to enforce header levels at that level, but I'm realizing that the header levels need to be enforced at the validator stage, not the lua stage. At this point, I'm simply enforcing headers to have a maximum value. 