### PR TITLE
fix alt attribute in episode template

### DIFF
--- a/inst/templates/episode-template.txt
+++ b/inst/templates/episode-template.txt
@@ -79,7 +79,7 @@ pie(
 
 Or you can use standard markdown for static figures:
 
-![You belong in The Carpentries!](https://raw.githubusercontent.com/carpentries/logo/master/Badge_Carpentries.svg){alt = 'Blue Carpentries hex person logo with no text.'}
+![You belong in The Carpentries!](https://raw.githubusercontent.com/carpentries/logo/master/Badge_Carpentries.svg){alt='Blue Carpentries hex person logo with no text.'}
 
 
 ## Math


### PR DESCRIPTION
The alt attribute tag had spaces padding the `=`, which is a nono in two languages that I know of: BASH and HTML 

This fixes that issue.