### PR TITLE
adds a minor update for syllabus rendering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9026
+Version: 0.0.0.9027
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9027
+
+MISC
+----
+
+* `create_schedule()` (internal function) no longer uses pegboard's extensions
+  for fixing reference links. 
+
 # sandpaper 0.0.0.9026
 
 MISC

--- a/R/get_syllabus.R
+++ b/R/get_syllabus.R
@@ -24,7 +24,7 @@ get_syllabus <- function(path = ".", questions = FALSE, use_built = TRUE) {
   # with each episode.
   
   sched    <- get_episodes(path)
-  lesson   <- pegboard::Lesson$new(path, jekyll = FALSE)
+  lesson   <- pegboard::Lesson$new(path, jekyll = FALSE, fix_links = FALSE)
   episodes <- lesson$episodes[sched]
   
   quest <- if (questions) vapply(episodes, get_questions, character(1)) else NULL


### PR DESCRIPTION
likely not user-visible.

This fix disables {pegboard} from trying to fix liquid style links in the document when it's read in to retrieve the schedule. 