### PR TITLE
Use relative paths for built database

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -107,6 +107,7 @@ jobs:
       - name: Check Test Lesson
         if: runner.os == 'macOS'
         run: |
+          remotes::install_local()
           stopifnot(
             "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")
           )

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Check on Lesson
         if: runner.os == 'macOS'
         run: |
-          usethis::use_github("carpentries/sandpaper-docs", 
+          usethis::create_from_github("carpentries/sandpaper-docs", 
             destdir = ".", fork = FALSE, open = FALSE)
           stopifnot(
             "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,7 +96,7 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
-      - name: Checkout Test Lesson
+      - name: Checkout Lesson for Integration Test
         if: runner.os == 'macOS'
         uses: actions/checkout@v2
         with:
@@ -104,18 +104,24 @@ jobs:
           path: ${{ github.workspace }}/sandpaper-docs 
           clean: false
 
-      - name: Check Test Lesson
+      - name: Perform Integration Test
         if: runner.os == 'macOS'
         run: |
           remotes::install_local()
           stopifnot(
             "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")
           )
-          sandpaper::build_lesson("sandpaper-docs")
+          ::group::Pre-built lesson tree
+          fs::dir_tree("sandpaper-docs")
+          ::endgroup::
+          ::group::Post-built lesson tree
+          sandpaper::build_lesson("sandpaper-docs", quiet = FALSE)
           stopifnot(
             "::error ::Markdown files not built" = fs::dir_exists("sandpaper-docs/site/built"),
             "::error ::HTML files not built" = fs::dir_exists("sandpaper-docs/site/docs")
           )
+          fs::dir_tree("sandpaper-docs")
+          ::endgroup::
         shell: Rscript {0}
 
       - name: Show testthat output

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,7 +96,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check on Lesson
-        if: runner.os == "macOS"
+        if: runner.os == 'macOS'
         run: |
           usethis::use_github("carpentries/sandpaper-docs", 
             destdir = ".", fork = FALSE, open = FALSE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,7 +100,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: actions/checkout@v2
         with:
-          repository = "carpentries/sandpaper-docs"
+          repository: "carpentries/sandpaper-docs"
           path: ${{ github.workspace }}/sandpaper-docs 
           clean: false
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -37,8 +37,9 @@ jobs:
       - name: Record Linux Version
         if: runner.os == 'Linux'
         run: echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
+      
+      - name: Checkout Package
+        uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@master
         with:
@@ -95,11 +96,17 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
-      - name: Check on Lesson
+      - name: Checkout Test Lesson
+        if: runner.os == 'macOS'
+        uses: actions/checkout@v2
+        with:
+          repository = "carpentries/sandpaper-docs"
+          path: ${{ github.workspace }}/sandpaper-docs 
+          clean: false
+
+      - name: Check Test Lesson
         if: runner.os == 'macOS'
         run: |
-          usethis::create_from_github("carpentries/sandpaper-docs", 
-            destdir = ".", fork = FALSE, open = FALSE)
           stopifnot(
             "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")
           )

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -111,17 +111,17 @@ jobs:
           stopifnot(
             "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")
           )
-          ::group::Pre-built lesson tree
+          cat("::group::Pre-built lesson tree")
           fs::dir_tree("sandpaper-docs")
-          ::endgroup::
-          ::group::Post-built lesson tree
+          cat("::endgroup::")
+          cat("::group::Post-built lesson tree")
           sandpaper::build_lesson("sandpaper-docs", quiet = FALSE)
           stopifnot(
             "::error ::Markdown files not built" = fs::dir_exists("sandpaper-docs/site/built"),
             "::error ::HTML files not built" = fs::dir_exists("sandpaper-docs/site/docs")
           )
           fs::dir_tree("sandpaper-docs")
-          ::endgroup::
+          cat("::endgroup::")
         shell: Rscript {0}
 
       - name: Show testthat output

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -95,6 +95,21 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
+      - name: Check on Lesson
+        if: runner.os == "macOS"
+        run: |
+          usethis::use_github("carpentries/sandpaper-docs", 
+            destdir = ".", fork = FALSE, open = FALSE)
+          stopifnot(
+            "::warning ::Could not clone test lesson" = fs::dir_exists("sandpaper-docs")
+          )
+          sandpaper::build_lesson("sandpaper-docs")
+          stopifnot(
+            "::error ::Markdown files not built" = fs::dir_exists("sandpaper-docs/site/built"),
+            "::error ::HTML files not built" = fs::dir_exists("sandpaper-docs/site/docs")
+          )
+        shell: Rscript {0}
+
       - name: Show testthat output
         if: always()
         run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9028
+Version: 0.0.0.9029
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sandpaper 0.0.0.9029
+
+The internal database is updated to use relative instead of absolute paths. 
+This fixes #129
+
 # sandpaper 0.0.0.9028
 
 NEW IMPORTS

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -30,7 +30,13 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
   db <- get_built_db(fs::path(built_path, "md5sum.txt"))
   db <- db[!grepl("(index|README|CONTRIBUTING)[.]md", db$built), , drop = FALSE]
   # Find all the episodes and get their range
-  er <- range(grep("/episodes/", db$file, fixed = TRUE))
+  er <- range(grep("episodes/", db$file, fixed = TRUE))
+
+  # Absolute paths for pandoc
+  abs_md  <- fs::path(path, db$built)
+  abs_src <- fs::path(path, db$file)
+
+  # comparison function to test if a within a range of 2 b numbers
   `%w%` <- function(a, b) a >= b[[1]] && a <= b[[2]]
 
   if (!quiet && requireNamespace("cli", quietly = TRUE)) {
@@ -39,10 +45,10 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
 
   for (i in seq_along(db$built)) {
     build_episode_html(
-      path_md      = db$built[i],
-      path_src     = db$file[i],
-      page_back    = if (i %w% er && i > er[1]) db$built[i - 1] else "index.md",
-      page_forward = if (i %w% er && i < er[2]) db$built[i + 1] else "index.md",
+      path_md      = abs_md[i],
+      path_src     = abs_src[i],
+      page_back    = if (i %w% er && i > er[1]) abs_md[i - 1] else "index.md",
+      page_forward = if (i %w% er && i < er[2]) abs_md[i + 1] else "index.md",
       pkg          = pkg, 
       quiet        = quiet
     )

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -37,12 +37,6 @@ path_profiles <- function(inpath) {
 get_resource_list <- function(path, trim = FALSE) {
   root <- root_path(path)
   cfg  <- get_config(root)
-  # res  <- rmarkdown::site_resources(
-  #   site_dir  = root,
-  #   include   = c("*md", include),
-  #   exclude   = c("site", exclude),
-  #   recursive = TRUE
-  # )
   res <- fs::dir_ls(
     root,
     regexp = "*[.](R?md|ipynb)$", # at the moment, we will only recognize Rmd,

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -19,5 +19,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Zhian N. Kamvar \email{zkamvar@gmail.com} (\href{https://orcid.org/0000-0003-1458-7108}{ORCID})
 
+Other contributors:
+\itemize{
+  \item François Michonneau \email{fmichonneau@carpentries.org} [contributor]
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
This will use relative paths for the internal database and will fix #129 

The only user visible change is that anyone with a current lesson using {sandpaper} (me!) will end up rebuilding the entire lesson.