### PR TITLE
fix test for pegboard 0.0.0.9017

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9029
+Version: 0.0.0.9030
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,17 @@
+# sandpaper 0.0.0.9030
+
+MISC
+----
+
+ - A test that caused problems with a new version of {pegboard} was fixed
+
 # sandpaper 0.0.0.9029
 
-The internal database is updated to use relative instead of absolute paths. 
-This fixes #129
+MISC
+----
+
+ - The internal database is updated to use relative instead of absolute paths. 
+   This fixes #129
 
 # sandpaper 0.0.0.9028
 

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -96,7 +96,7 @@ test_that("yaml lists are preserved with other schedule updates", {
   
   # regression test for https://github.com/carpentries/sandpaper/issues/53
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
-  set_learners(tmp, order = "setup.md", write = TRUE)
+  set_learners(tmp, order = "Setup.md", write = TRUE)
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
 
 })


### PR DESCRIPTION
This is a small fix for the changes in https://github.com/carpentries/pegboard/pull/43, which highlighted a small error in the validation of one of our tests here. 