### PR TITLE
Refactor get_dropdown()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9031
+Version: 0.0.0.9032
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9001
 URL: https://github.com/carpentries/sandpaper/
 BugReports: https://github.com/carpentries/sandpaper/issues/
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@ MISC
  - The internal `get_resource_list()` function has been modified to incorporate
    the features of `get_dropdown()`. This means that all `get_dropdown()`
    functions will only report the files in the dropdown menus that actually
-   exist in the directory.
+   exist in the directory (#134).
+ - A persistant test fixture is now included to speed up testing time (#132 via
+   #134)
 
 # sandpaper 0.0.0.9031
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9032
+
+MISC
+----
+
+ - The internal `get_resource_list()` function has been modified to incorporate
+   the features of `get_dropdown()`. 
+
 # sandpaper 0.0.0.9031
 
 MISC

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@ MISC
 ----
 
  - The internal `get_resource_list()` function has been modified to incorporate
-   the features of `get_dropdown()`. 
+   the features of `get_dropdown()`. This means that all `get_dropdown()`
+   functions will only report the files in the dropdown menus that actually
+   exist in the directory.
 
 # sandpaper 0.0.0.9031
 

--- a/R/get_dropdown.R
+++ b/R/get_dropdown.R
@@ -13,12 +13,8 @@
 #' get_episodes(tmp)
 #' get_learners(tmp) # information for learners
 get_dropdown <- function(path = ".", folder, trim = TRUE) {
-  cfg <- path_config(path)
-  if (!fs::file_exists(cfg)) {
-    stop("config file does not exist")
-  }
   episode <- folder == "episodes"
-  yaml <- yaml::read_yaml(cfg)
+  yaml <- get_config(path)
   scd <- yaml[[folder]]
   scd <- if (episode && is.null(scd)) yaml[["schedule"]] else scd
   unset <- is.null(scd)

--- a/R/get_dropdown.R
+++ b/R/get_dropdown.R
@@ -1,61 +1,47 @@
-#' Get the contents of a dropdown on the site
+#' Helpers to extract contents of dropdown menus on the site
+#'
+#' This fuction will extract the resources that exist and are listed in the
+#' config file.
 #'
 #' @param path the path to the lesson, defaults to the current working directory
-#' @param folder the name of the folder containing the dropdown items
+#' @param folder the folder to extract fromt he dropdown menues
 #' @param trim if `TRUE` (default), only the file name will be presented. When
 #'   `FALSE`, the full path will be prepended.
 #' @return a character vector of episodes in order of presentation
 #'
 #' @export
+#' @rdname get_dropdown
 #' @examples
 #' tmp <- tempfile()
 #' create_lesson(tmp)
 #' get_episodes(tmp)
 #' get_learners(tmp) # information for learners
 get_dropdown <- function(path = ".", folder, trim = TRUE) {
-  episode <- folder == "episodes"
-  yaml <- get_config(path)
-  scd <- yaml[[folder]]
-  scd <- if (episode && is.null(scd)) yaml[["schedule"]] else scd
-  unset <- is.null(scd)
-  # Return early if we only want the defined schedule
-  if (!unset && trim) {
-    return(scd)
-  }
-  # If the resources are unset in the yaml, get the sources
-  if (unset) {
-    if (episode) warn_schedule()
-    scd <- get_sources(path, folder)
-  # If they are set, make sure they are in the right order.
-  } else {
-    src <- get_sources(path, folder)
-    scd <- src[match(scd, basename(src))]
-  } 
-  if (trim) basename(scd) else scd
+  as.character(get_resource_list(path, trim, folder, warn = TRUE))
 }
 
 #' @rdname get_dropdown
 #' @export
 get_episodes <- function(path = ".", trim = TRUE) {
-  get_dropdown(path, "episodes", trim)
+  as.character(get_resource_list(path, trim, "episodes", warn = TRUE))
 }
 
 #' @rdname get_dropdown
 #' @export
 get_learners <- function(path = ".", trim = TRUE) {
-  get_dropdown(path, "learners", trim)
+  as.character(get_resource_list(path, trim, "learners", warn = TRUE))
 }
 
 #' @rdname get_dropdown
 #' @export
 get_instructors <- function(path = ".", trim = TRUE) {
-  get_dropdown(path, "instructors", trim)
+  as.character(get_resource_list(path, trim, "instructors", warn = TRUE))
 }
 
 #' @rdname get_dropdown
 #' @export
 get_profiles <- function(path = ".", trim = TRUE) {
-  get_dropdown(path, "profiles", trim)
+  as.character(get_resource_list(path, trim, "profiles", warn = TRUE))
 }
 
 warn_schedule <- function() {

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -30,19 +30,60 @@ path_profiles <- function(inpath) {
 #' @param path path to the lesson
 #' @param trim if `TRUE`, trim the paths to be relative to the lesson directory.
 #'   Defaults to `FALSE`, which will return the absolute paths
+#' @param subfolder the subfolder to check. If this is `NULL`, all folders will
+#'   checked and returned (default), otherwise, this should be a string 
+#'   specifying the folder name in the lesson (e.g. "episodes").
+#' @param warn if `TRUE` and `subfolder = "episodes"`, a message is issued to
+#'   the user if the episodes field of the configuration file is empty.
 #' @return a list of files by subfolder in the order they should appear in the
 #'   menu.
 #' @keywords internal
 #' @seealso [build_status()]
-get_resource_list <- function(path, trim = FALSE) {
+get_resource_list <- function(path, trim = FALSE, subfolder = NULL, warn = FALSE) {
   root <- root_path(path)
+  root_path <- root
+  recurse <- 1L
   cfg  <- get_config(root)
+  use_subfolder <- !is.null(subfolder) &&
+    length(subfolder) == 1L &&
+    is.character(subfolder)
+
+  # Using a subfolder should return a vector of files, but we need to check for
+  # a few things first:
+  #
+  #  1. If the user has an old version of the lesson, we forgive them and use a
+  #     more current version
+  #  2. Check that the subfolder actually exists in the config file
+  #  3. Warn if the episode order has not been set.
+  if (use_subfolder) {
+    is_episodes <- subfolder == "episodes"
+    old_version <- is_episodes && "schedule" %in% names(cfg)
+
+    if (old_version) {
+      names(cfg)[names(cfg) == "schedule"] <- "episodes"
+    }
+
+    subfolder_exists <- subfolder %in% names(cfg)
+    if (!subfolder_exists) {
+      stop(glue::glue(
+        "{subfolder} is not listed in {fs::path(root, 'config.yaml')}"
+      ), call. = FALSE)
+    }
+
+    should_warn <- warn && is_episodes && is.null(cfg[["episodes"]])
+    if (should_warn) warn_schedule()
+
+    recurse   <- FALSE
+    root_path <- fs::path(root, subfolder)
+  }
+
+
   res <- fs::dir_ls(
-    root,
+    root_path,
     regexp = "*[.](R?md|ipynb)$", # at the moment, we will only recognize Rmd,
                                   # and ipynb files (although we do not support
                                   # the latter at the moment).
-    recurse = 1,# only move into the source folders
+    recurse = recurse, # only move into the source folders
     type = "file",
     fail = FALSE
   )
@@ -54,23 +95,30 @@ get_resource_list <- function(path, trim = FALSE) {
 
   # Split the files into a list.
   if (trim) {
-    res <- fs::path_rel(res, root)
+    res <- fs::path_rel(res, root_path)
     res <- split(res, fs::path_dir(res))
   } else {
     res <- split(res, fs::path_rel(fs::path_dir(res), root))
   }
+  
+  if (use_subfolder) {
+    names(res) <- subfolder
+  } else {
+    subfolder <- c("episodes", "learners", "instructors", "profiles")
+  }
 
   # These are the only four items that we need to consider order for. 
-  for (i in c("episodes", "learners", "instructors", "profiles")) {
+  for (i in subfolder) {
     config_order <- cfg[[i]]
     # If the configuration is not missing, then we have to rearrange the order.
     if (!is.null(config_order)) {
+      # Confirm that the order exists
       paths         <- res[[i]]
       default_order <- fs::path_file(paths)
       res[[i]]      <- paths[match(config_order, default_order, nomatch = 0)]
     }
   }
-  res[names(res) != "site"]
+  if (use_subfolder) res[[subfolder]] else res[names(res) != "site"]
 }
 
 get_sources <- function(path, subfolder = "episodes") {

--- a/man/check_lesson.Rd
+++ b/man/check_lesson.Rd
@@ -23,7 +23,7 @@ Check the lesson structure for errors
 
 # Everything should work out of the box
 tmp <- tempfile()
-create_lesson(tmp)
+create_lesson(tmp, open = FALSE)
 check_lesson(tmp)
 
 # if things do not work, then an error is thrown with information about 

--- a/man/get_dropdown.Rd
+++ b/man/get_dropdown.Rd
@@ -6,7 +6,7 @@
 \alias{get_learners}
 \alias{get_instructors}
 \alias{get_profiles}
-\title{Get the contents of a dropdown on the site}
+\title{Helpers to extract contents of dropdown menus on the site}
 \usage{
 get_dropdown(path = ".", folder, trim = TRUE)
 
@@ -21,7 +21,7 @@ get_profiles(path = ".", trim = TRUE)
 \arguments{
 \item{path}{the path to the lesson, defaults to the current working directory}
 
-\item{folder}{the name of the folder containing the dropdown items}
+\item{folder}{the folder to extract fromt he dropdown menues}
 
 \item{trim}{if \code{TRUE} (default), only the file name will be presented. When
 \code{FALSE}, the full path will be prepended.}
@@ -30,7 +30,8 @@ get_profiles(path = ".", trim = TRUE)
 a character vector of episodes in order of presentation
 }
 \description{
-Get the contents of a dropdown on the site
+This fuction will extract the resources that exist and are listed in the
+config file.
 }
 \examples{
 tmp <- tempfile()

--- a/man/get_resource_list.Rd
+++ b/man/get_resource_list.Rd
@@ -4,13 +4,20 @@
 \alias{get_resource_list}
 \title{Get the full resource list of markdown files}
 \usage{
-get_resource_list(path, trim = FALSE)
+get_resource_list(path, trim = FALSE, subfolder = NULL, warn = FALSE)
 }
 \arguments{
 \item{path}{path to the lesson}
 
 \item{trim}{if \code{TRUE}, trim the paths to be relative to the lesson directory.
 Defaults to \code{FALSE}, which will return the absolute paths}
+
+\item{subfolder}{the subfolder to check. If this is \code{NULL}, all folders will
+checked and returned (default), otherwise, this should be a string
+specifying the folder name in the lesson (e.g. "episodes").}
+
+\item{warn}{if \code{TRUE} and \code{subfolder = "episodes"}, a message is issued to
+the user if the episodes field of the configuration file is empty.}
 }
 \value{
 a list of files by subfolder in the order they should appear in the

--- a/man/sandpaper_site.Rd
+++ b/man/sandpaper_site.Rd
@@ -12,7 +12,7 @@ This is a custom site generator for compatibility with
 the \code{index.md} yaml header will make the knit button work}:
 }
 \details{
-\if{html}{\out{<div class="yaml">}}\preformatted{site: sandpaper::sandpaper_site
+\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{site: sandpaper::sandpaper_site
 }\if{html}{\out{</div>}}
 
 This will be automatically added to the \code{index.md} for all sandpaper sites

--- a/man/yaml_list.Rd
+++ b/man/yaml_list.Rd
@@ -16,14 +16,14 @@ We want to manipulate our config file from the command line AND preserve
 comments. Unfortunately, the yaml C library does not parse comments and it
 makes things difficult to handle. At the moment we have a hack where we use
 whisker templates for these, but the drawback for whisker is that it does not
-know how to handle lists, so it concatenates them with commas:\if{html}{\out{<div class="r">}}\preformatted{x <- c("a", "b", "c")
+know how to handle lists, so it concatenates them with commas:\if{html}{\out{<div class="sourceCode r">}}\preformatted{x <- c("a", "b", "c")
 hx <- list(hello = x)
 cat(yaml::as.yaml(hx)) # representation in yaml
 }\if{html}{\out{</div>}}\preformatted{## hello:
 ## - a
 ## - b
 ## - c
-}\if{html}{\out{<div class="r">}}\preformatted{cat(whisker::whisker.render("hello: \{\{hello\}\}", hx)) # messed up whisker
+}\if{html}{\out{<div class="sourceCode r">}}\preformatted{cat(whisker::whisker.render("hello: \{\{hello\}\}", hx)) # messed up whisker
 }\if{html}{\out{</div>}}\preformatted{## hello: a,b,c
 }
 
@@ -36,7 +36,7 @@ and not\preformatted{key: value1
 }
 
 This converts the elements to a yaml list before it enters whisker and makes
-sure that the values are clearly lists.\if{html}{\out{<div class="r">}}\preformatted{hx[["hello"]] <- sandpaper:::yaml_list(hx[["hello"]])
+sure that the values are clearly lists.\if{html}{\out{<div class="sourceCode r">}}\preformatted{hx[["hello"]] <- sandpaper:::yaml_list(hx[["hello"]])
 cat(whisker::whisker.render("hello: \{\{hello\}\}", hx)) # good whisker
 }\if{html}{\out{</div>}}\preformatted{## hello: 
 ## - a

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,9 +1,19 @@
 {
-cli::cli_alert_info("Bootstrapping example lesson")
-
+if (interactive()) {
+  try({
+stat <- cli::cli_status("{cli::symbol$arrow_right} Bootstrapping example lesson")
+  })
+}
 tmpdir <- fs::file_temp()
 fs::dir_create(tmpdir)
 tmp <- fs::path(tmpdir, "lesson-example")
+if (interactive()) {
+  try({
+    cli::cli_status_update(id = stat,
+      "{cli::symbol$arrow_right} Bootstrapping example lesson in {tmp}"
+    )
+  })
+}
 res <- create_lesson(tmp, open = FALSE)
 
 options(sandpaper.test_fixture = res)
@@ -30,8 +40,21 @@ restore_fixture <- function() {
   create_site(tf)
   tf
 }
-
+if (interactive()) {
+  try({
+    cli::cli_alert_info(id = stat, "Example lesson in {tmp}")
+  })
+}
 
 # Run after all tests
-withr::defer(fs::dir_delete(getOption("sandpaper.test_fixture")), teardown_env())
+withr::defer({
+  tf <- getOption("sandpaper.test_fixture")
+  fs::dir_delete(tf)
+  if (interactive() && !fs::dir_exists(tf)) {
+    if (!fs::dir_exists(tf)) 
+      try(cli::cli_alert_info("{tf} successfully removed"))
+    else
+      try(cli::cli_alert_danger("{tf} could not be removed"))
+  }
+}, teardown_env())
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,37 @@
+{
+cli::cli_alert_info("Bootstrapping example lesson")
+
+tmpdir <- fs::file_temp()
+fs::dir_create(tmpdir)
+tmp <- fs::path(tmpdir, "lesson-example")
+res <- create_lesson(tmp, open = FALSE)
+
+options(sandpaper.test_fixture = res)
+
+restore_fixture <- function() {
+  tf <- getOption("sandpaper.test_fixture")
+  if (nrow(gert::git_status(tf)) > 0L) {
+    x <- gert::git_reset_hard(repo = tf)
+    if (nrow(x) > 0L) {
+      files <- fs::path(tf, x$file)
+      dirs  <- fs::is_dir(files)
+      tryCatch({
+        fs::file_delete(files[!dirs])
+        fs::dir_delete(files[dirs])
+      },
+        error = function(x) {}
+      )
+      if (any(dirs)) {
+        fs::dir_create(files[dirs])
+      }
+    }
+  }
+  fs::dir_delete(fs::path(tf, "site"))
+  create_site(tf)
+  tf
+}
+
+
+# Run after all tests
+withr::defer(fs::dir_delete(getOption("sandpaper.test_fixture")), teardown_env())
+}

--- a/tests/testthat/test-build_episode.R
+++ b/tests/testthat/test-build_episode.R
@@ -26,11 +26,7 @@ test_that("build_episode_md() works independently", {
 test_that("build_episode_html() works independently", {
 
 
-  tmpdir <- fs::file_temp()
-  fs::dir_create(tmpdir)
-  tmp    <- fs::path(tmpdir, "lesson-example")
-  expect_equal(basename(create_lesson(tmp, open = FALSE)), basename(tmp))
-  reset_site(tmp)
+  tmp <- restore_fixture()
   pkg <- pkgdown::as_pkgdown(file.path(tmp, "site"))
   expect_output(pkgdown::init_site(pkg))
   

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -1,14 +1,7 @@
 
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp    <- fs::path(tmpdir, "lesson-example")
+tmp <- res <- restore_fixture()
 sitepath <- fs::path(tmp, "site", "docs")
-withr::defer(fs::dir_delete(tmp))
 
-test_that("A lesson can be created in a non-existent directory", {
-  expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp, open = FALSE)
-})
 
 test_that("Lessons built for the first time are noisy", {
   

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -1,10 +1,6 @@
 # setup test fixture
 {
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp <- res <- fs::path(tmpdir, "lesson-example")
-withr::defer(fs::dir_delete(tmp))
-res <- create_lesson(tmp, open = FALSE)
+tmp <- res <- restore_fixture()
 create_episode("second-episode", path = tmp)
 instruct <- fs::path(tmp, "instructors", "pyramid.md")
 writeLines(c(

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -26,7 +26,7 @@ test_that("markdown sources can be built without fail", {
   # The episodes should be the only things in the directory
   e <- fs::dir_ls(fs::path(tmp, "episodes"), recurse = TRUE, type = "file")
   s <- get_episodes(tmp)
-  expect_equal(fs::path_file(e), s)
+  expect_equal(fs::path_file(e), s, ignore_attr = TRUE)
 
   skip_if_not(rmarkdown::pandoc_available("1.12.3"))
   # Accidentally rendered html live in their parent folders
@@ -90,7 +90,7 @@ test_that("Artifacts are accounted for", {
   s <- get_episodes(tmp)
   # No artifacts should be present in the directory
   e <- fs::dir_ls(fs::path(tmp, "episodes"), recurse = TRUE, type = "file")
-  expect_equal(fs::path_file(e), s)
+  expect_equal(fs::path_file(e), s, ignore_attr = TRUE)
   # The artifacts are present in the built directory
   b <- c(
     # Generated markdown files

--- a/tests/testthat/test-clear_site.R
+++ b/tests/testthat/test-clear_site.R
@@ -1,14 +1,8 @@
+tmp <- res <- restore_fixture()
+suppressMessages(s <- get_episodes(tmp))
+set_episodes(tmp, s, write = TRUE)
+
 test_that("the site can be cleared", {
-
-  tmpdir <- fs::file_temp()
-  fs::dir_create(tmpdir)
-  tmp    <- fs::path(tmpdir, "lesson-example")
-
-  withr::defer(fs::dir_delete(tmp))
-  expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp, open = FALSE)
-  suppressMessages(s <- get_episodes(tmp))
-  set_episodes(tmp, s, write = TRUE)
 
   # Make sure everything exists
   expect_true(check_lesson(tmp))

--- a/tests/testthat/test-create_episode.R
+++ b/tests/testthat/test-create_episode.R
@@ -1,10 +1,4 @@
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp    <- fs::path(tmpdir, "lesson-example")
-
-withr::defer(fs::dir_delete(tmp))
-expect_false(fs::dir_exists(tmp))
-res <- create_lesson(tmp, open = FALSE)
+tmp <- res <- restore_fixture()
 
 test_that("prefixed episodes can be created", {
 
@@ -29,12 +23,8 @@ test_that("prefixed episodes can be created", {
 })
 
 test_that("un-prefixed episodes can be created", {
-
-
   third_episode <- create_episode("third-script", make_prefix = FALSE, path = tmp) %>%
     expect_match("third-script.Rmd", fixed = TRUE)
 
   expect_true(check_episode(third_episode))
- 
-
 })

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -1,15 +1,15 @@
 {
   tmpdir <- fs::file_temp()
   fs::dir_create(tmpdir)
-  tmp    <- fs::path(tmpdir, "lesson-example")
-
+  tmp    <- fs::path(tmpdir, "lesson-init-example")
   withr::defer(fs::dir_delete(tmp))
-  expect_false(fs::dir_exists(tmp))
   wd  <- fs::path(normalizePath(getwd()))
   withr::defer(setwd(wd))
 }
+
 test_that("lessons can be created in empty directories", {
 
+  expect_false(fs::dir_exists(tmp))
   suppressMessages({expect_message({
     res <- create_lesson(tmp, rstudio = TRUE, open = TRUE)
   }, "Setting active project to")})
@@ -47,7 +47,7 @@ test_that("All template files exist", {
   expect_true(fs::dir_exists(fs::path(tmp, "learners")))
   expect_true(fs::dir_exists(fs::path(tmp, "profiles")))
   expect_true(fs::file_exists(fs::path(tmp, "README.md")))
-  expect_match(readLines(fs::path(tmp, "README.md"))[1], "lesson-example", fixed = TRUE) 
+  expect_match(readLines(fs::path(tmp, "README.md"))[1], "lesson-init-example", fixed = TRUE) 
   expect_true(fs::file_exists(fs::path(tmp, "site", "README.md")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "DESCRIPTION")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "_pkgdown.yaml")))

--- a/tests/testthat/test-get_dropdown.R
+++ b/tests/testthat/test-get_dropdown.R
@@ -1,10 +1,5 @@
 {
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp    <- fs::path(tmpdir, "lesson-example")
-withr::defer(fs::dir_delete(tmp))
-expect_false(fs::dir_exists(tmp))
-res <- create_lesson(tmp, open = FALSE)
+tmp <- res <- restore_fixture()
 create_episode("outroduction", path = res)
 outro <- fs::path(res, "episodes", "02-outroduction.Rmd")
 fs::file_move(outro, fs::path_ext_set(outro, "md"))

--- a/tests/testthat/test-get_episode.R
+++ b/tests/testthat/test-get_episode.R
@@ -1,11 +1,12 @@
 {
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp    <- fs::path(tmpdir, "lesson-example")
-withr::defer(fs::dir_delete(tmp))
-res <- create_lesson(tmp, open = FALSE)
-suppressMessages(e <- get_episodes(res))
-set_episodes(res, e, write = TRUE)
+# tmpdir <- fs::file_temp()
+# fs::dir_create(tmpdir)
+# tmp    <- fs::path(tmpdir, "lesson-example")
+# withr::defer(fs::dir_delete(tmp))
+# res <- create_lesson(tmp, open = FALSE)
+# suppressMessages(e <- get_episodes(res))
+# set_episodes(res, e, write = TRUE)
+tmp <- res <- restore_fixture()
 }
 
 test_that("set_episode() will throw a warning if an episode does not exist", {

--- a/tests/testthat/test-get_episode.R
+++ b/tests/testthat/test-get_episode.R
@@ -1,3 +1,43 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
+{
+tmpdir <- fs::file_temp()
+fs::dir_create(tmpdir)
+tmp    <- fs::path(tmpdir, "lesson-example")
+withr::defer(fs::dir_delete(tmp))
+res <- create_lesson(tmp, open = FALSE)
+suppressMessages(e <- get_episodes(res))
+set_episodes(res, e, write = TRUE)
+}
+
+test_that("set_episode() will throw a warning if an episode does not exist", {
+
+  skip("currently writing")
+  bad <- c(e, "I-do-not-exist.md")
+
+  expect_message(set_episodes(res, bad, write = TRUE))
+
+  expect_silent(bad_out <- get_episodes(res))
+
+  expect_equal(bad_out, e)
+
+})
+
+test_that("get_episode() will throw a warning if an episode in config does not exist", {
+
+  # Create a new episode that does not exist
+  skip("currently writing")
+  cfg <- readLines(fs::path(res, "config.yaml"), encoding = "UTF-8")
+  episode_line <- grep("^episodes", cfg)
+
+  new_cfg <- c(
+    cfg[seq(episode_line + 1L)], 
+    "- I-am-an-impostor.md", 
+    cfg[seq(episode_line + 2L, length(cfg))]
+  )
+
+  writeLines(new_cfg, fs::path(res, "config.yaml"))
+
+  expect_message(bad_out <- get_episodes(res))
+
+  expect_equal(bad_out, e)
+
 })

--- a/tests/testthat/test-get_syllabus.R
+++ b/tests/testthat/test-get_syllabus.R
@@ -1,10 +1,11 @@
 {
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp <- fs::path(tmpdir, "lesson-example")
+# tmpdir <- fs::file_temp()
+# fs::dir_create(tmpdir)
+# tmp <- fs::path(tmpdir, "lesson-example")
+# withr::defer(fs::dir_delete(tmp))
+# res <- create_lesson(tmp, open = FALSE, rstudio = FALSE)
 q <- "How do you write a lesson using RMarkdown and `{sandpaper}`?"
-withr::defer(fs::dir_delete(tmp))
-res <- create_lesson(tmp, open = FALSE, rstudio = FALSE)
+tmp <- res <- restore_fixture()
 }
 
 test_that("syllabus can be extracted from source files", {

--- a/tests/testthat/test-sandpaper_site.R
+++ b/tests/testthat/test-sandpaper_site.R
@@ -1,12 +1,6 @@
 test_that("sandpaper_site produces a renderer", {
 
-  tmpdir <- fs::file_temp()
-  fs::dir_create(tmpdir)
-  tmp    <- fs::path(tmpdir, "lesson-example")
-
-  withr::defer(fs::dir_delete(tmp))
-  expect_false(fs::dir_exists(tmp))
-  res <- create_lesson(tmp, open = FALSE)
+  tmp <- res <- restore_fixture()
   withr::with_dir(tmp, res <- sandpaper_site())
   expect_type(res, "list")
   expect_named(res, c("name", "output_dir", "render", "clean", "subdirs"))

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -1,10 +1,4 @@
-{
-tmpdir <- fs::file_temp()
-fs::dir_create(tmpdir)
-tmp    <- fs::path(tmpdir, "lesson-example")
-withr::defer(fs::dir_delete(tmp))
-res <- create_lesson(tmp, open = FALSE)
-}
+tmp <- res <- restore_fixture()
 
 test_that("schedule is empty by default", {
 

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -10,10 +10,10 @@ test_that("schedule is empty by default", {
 
   cfg <- get_config(tmp)
   suppressMessages(s <- get_episodes(tmp))
-  expect_equal(s, "01-introduction.Rmd")
+  expect_equal(s, "01-introduction.Rmd", ignore_attr = TRUE)
   expect_null(set_episodes(tmp, s, write = TRUE))
   expect_silent(s <- get_episodes(tmp))
-  expect_equal(s, "01-introduction.Rmd")
+  expect_equal(s, "01-introduction.Rmd", ignore_attr = TRUE)
 
   # the config files should be unchanged from the schedule
   no_episodes <- names(cfg)[names(cfg) != "episodes"]
@@ -25,7 +25,7 @@ test_that("new episodes will not add to the schedule by default", {
 
   set_episodes(tmp, "01-introduction.Rmd", write = TRUE)
   create_episode("new", path = tmp)
-  expect_equal(get_episodes(tmp), "01-introduction.Rmd")
+  expect_equal(get_episodes(tmp), "01-introduction.Rmd", ignore_attr = TRUE)
 
 })
 
@@ -34,9 +34,9 @@ test_that("get_episodes() returns episodes in dir if schedule is not set", {
 
   reset_episodes(tmp)
   suppressMessages(expect_message(s <- get_episodes(tmp)))
-  expect_equal(s, c("01-introduction.Rmd", "02-new.Rmd"))
+  expect_equal(s, c("01-introduction.Rmd", "02-new.Rmd"), ignore_attr = TRUE)
   set_episodes(tmp, s[1], write = TRUE)
-  expect_equal(get_episodes(tmp), s[1])
+  expect_equal(get_episodes(tmp), s[1], ignore_attr = TRUE)
 
 })
 
@@ -49,12 +49,12 @@ cli::test_that_cli("set_episodes() will display the modifications if write is no
 
   expect_equal(s, c("01-introduction.Rmd", "02-new.Rmd"))
   set_episodes(tmp, s, write = TRUE)
-  expect_equal(get_episodes(tmp), s)
+  expect_equal(get_episodes(tmp), s, ignore_attr = TRUE)
 
   expect_snapshot(set_episodes(tmp, s[1]))
-  expect_equal(get_episodes(tmp), s)
+  expect_equal(get_episodes(tmp), s, ignore_attr = TRUE)
   set_episodes(tmp, s[1], write = TRUE)
-  expect_equal(get_episodes(tmp), s[1])
+  expect_equal(get_episodes(tmp), s[1], ignore_attr = TRUE)
 
 }, configs = "plain")
 
@@ -71,7 +71,7 @@ test_that("adding episodes will concatenate the schedule", {
   expect_equal(get_episodes(tmp), "01-introduction.Rmd")
   create_episode("second-episode", add = TRUE, path = tmp)
   expect_equal(res, tmp, ignore_attr = TRUE)
-  expect_equal(get_episodes(tmp), c("01-introduction.Rmd", "03-second-episode.Rmd"))
+  expect_equal(get_episodes(tmp), c("01-introduction.Rmd", "03-second-episode.Rmd"), ignore_attr = TRUE)
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
 
@@ -87,7 +87,7 @@ test_that("adding episodes will concatenate the schedule", {
 test_that("the schedule can be rearranged", {
 
   set_episodes(tmp, c("03-second-episode.Rmd", "01-introduction.Rmd"), write = TRUE)
-  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
+  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"), ignore_attr = TRUE)
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
 
@@ -103,16 +103,16 @@ test_that("yaml lists are preserved with other schedule updates", {
   
   set_episodes(tmp, c("03-second-episode.Rmd", "01-introduction.Rmd"), write = TRUE)
   # regression test for https://github.com/carpentries/sandpaper/issues/53
-  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
+  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"), ignore_attr = TRUE)
   set_learners(tmp, order = "Setup.md", write = TRUE)
-  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
+  expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"), ignore_attr = TRUE)
 
 })
 
 test_that("the schedule can be truncated", {
 
   set_episodes(tmp, "01-introduction.Rmd", write = TRUE)
-  expect_equal(get_episodes(tmp), "01-introduction.Rmd")
+  expect_equal(get_episodes(tmp), "01-introduction.Rmd", ignore_attr = TRUE)
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
 

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -43,6 +43,7 @@ test_that("get_episodes() returns episodes in dir if schedule is not set", {
 
 cli::test_that_cli("set_episodes() will display the modifications if write is not specified", {
 
+  # Is this skipped on CRAN?
   reset_episodes(tmp)
   expect_snapshot(s <- get_episodes(tmp))
 
@@ -66,6 +67,7 @@ test_that("set_episodes() will error if no proposal is defined", {
 
 test_that("adding episodes will concatenate the schedule", {
 
+  set_episodes(tmp, "01-introduction.Rmd", write = TRUE)
   expect_equal(get_episodes(tmp), "01-introduction.Rmd")
   create_episode("second-episode", add = TRUE, path = tmp)
   expect_equal(res, tmp, ignore_attr = TRUE)
@@ -84,7 +86,7 @@ test_that("adding episodes will concatenate the schedule", {
 
 test_that("the schedule can be rearranged", {
 
-  set_episodes(tmp, rev(get_episodes(tmp)), write = TRUE)
+  set_episodes(tmp, c("03-second-episode.Rmd", "01-introduction.Rmd"), write = TRUE)
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
@@ -99,6 +101,7 @@ test_that("the schedule can be rearranged", {
 
 test_that("yaml lists are preserved with other schedule updates", {
   
+  set_episodes(tmp, c("03-second-episode.Rmd", "01-introduction.Rmd"), write = TRUE)
   # regression test for https://github.com/carpentries/sandpaper/issues/53
   expect_equal(get_episodes(tmp), c("03-second-episode.Rmd", "01-introduction.Rmd"))
   set_learners(tmp, order = "Setup.md", write = TRUE)
@@ -108,7 +111,7 @@ test_that("yaml lists are preserved with other schedule updates", {
 
 test_that("the schedule can be truncated", {
 
-  set_episodes(tmp, rev(get_episodes(tmp))[1], write = TRUE)
+  set_episodes(tmp, "01-introduction.Rmd", write = TRUE)
   expect_equal(get_episodes(tmp), "01-introduction.Rmd")
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))


### PR DESCRIPTION
This refactor of `get_dropdown()` helps centralize the coordinators between the config and the source files, thus addressing part of #101 

This also introduces a test fixture to fix #132, which knocks off >30 seconds from the tests. 