### PR TITLE
update pr template to not escape HTML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9036
+Version: 0.0.0.9037
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -19,7 +19,6 @@ Imports:
     pegboard (>= 0.0.0.9014),
     cli (>= 2.0.2),
     commonmark,
-    xml2,
     fs,
     gh,
     gert (>= 1.0.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.0.0.9037
+
+MISC
+----
+
+ - Output of `ci_bundle_pr_artifacts()` no longer escapes HTML-like output in
+   the diff summary. 
+ - remove {xml2} from explicit dependencies
+
 # sandpaper 0.0.0.9036
 
 MISC
@@ -9,6 +18,7 @@ MISC
    artifacts for GitHub to upload upon receipt of a pull request. This will
    replace clunky shell code that lived inside a YAML configuration file.
    (@zkamvar, #139)
+ - add {brio} to soft dependencies (for testing, but maybe could speed up???)
 
 # sandpaper 0.0.0.9035
 

--- a/inst/templates/pr_diff-template.txt
+++ b/inst/templates/pr_diff-template.txt
@@ -22,7 +22,7 @@ should check for the following:
 The following changes were observed in the _rendered_ markdown documents:
 
 ```
-{{ summary_of_differences }}
+{{{ summary_of_differences }}}
 ```
 
 <details>


### PR DESCRIPTION
THis is a very _minor_ change, but will fix how the PR templates will show up.