### PR TITLE
Fix worktree fetch mechanism

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9037
+Version: 0.0.0.9038
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.0.0.9038
+
+MISC
+----
+
+ - Trying to find fix for broken builds
+
 # sandpaper 0.0.0.9037
 
 MISC

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 MISC
 ----
 
- - Trying to find fix for broken builds
+ - Fix broken deploy process on continuous integration caused by attempting to
+   fetch all branches in a shallow clone (@zkamvar, #142)
 
 # sandpaper 0.0.0.9037
 

--- a/R/ci_deploy.R
+++ b/R/ci_deploy.R
@@ -43,20 +43,26 @@ ci_deploy <- function(path = ".", md_branch = "md-outputs", site_branch = "gh-pa
 
     on.exit(eval(del_site), add = TRUE)
 
+    ci_group("Build Lesson")
     # Build the site quickly using the markdown files as-is
-    build_lesson(path = path, quiet = TRUE, rebuild = FALSE, preview = FALSE)
+    build_lesson(path = path, quiet = FALSE, rebuild = FALSE, preview = FALSE)
+    cli::cat_line("::endgroup::")
 
     # Commit the markdown sources
+    ci_group("Commit Markdown Sources")
     github_worktree_commit(built, 
       message_source("markdown source builds", current, dir = path),
       remote, md_branch 
     )
+    cli::cat_line("::endgroup::")
 
     # Commit using the markdown branch as a reference
+    ci_group("Commit website")
     github_worktree_commit(html,
       message_source("site deploy", md_branch, dir = built),
       remote, site_branch
     )
+    cli::cat_line("::endgroup::")
   })}
   invisible()
 }

--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -3,6 +3,10 @@ remove_cli_decoration <- function(msg) {
   gsub(" [{][^ ]*[ ]?", " `", msg)
 }
 
+ci_group <- function(group = "Group") {
+  cli::cat_line(glue::glue("::group::{group}"))
+}
+
 sandpaper_cli_theme <- function() {
   list(
     ul = list(

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -22,20 +22,13 @@ fetch_one_branch <- function(remote, branch, repo = ".") {
   # NOTE: We only want to fetch ONE branch and ONE branch, only. We apparently
   # cannot do this by specifying a refspec for fetch, but we _can_ temporarily
   # modify the refspec for for the repo.
-  # fetch the content of only the branch in question
   # https://stackoverflow.com/a/62264058/2752888
-  cli::cat_line("Temporarily changing config...")
-  refspec <- glue::glue("+refs/heads/{branch}:refs/remotes/{remote}/{branch}")
-  cfg_fetch <- glue::glue("remote.{remote}.fetch")
-  cli::cat_line(glue::glue("Running git config {cfg_fetch} {refspec}"))
-  cfg <- gert::git_config_set(cfg_fetch, refspec, repo = repo)
+  git("remote", "set-branches", remote, branch)
   on.exit({
     # https://stackoverflow.com/a/47726250/2752888
-    cli::cat_line(glue::glue("Running git config {cfg_fetch} {cfg}"))
-    gert::git_config_set(cfg_fetch, cfg, repo = repo)
+    git("remote", "set-branches", remote, "*")
   })
-  cli::cat_line("Fetching {branch}")
-  gert::git_fetch(remote = remote, refspec = refspec, repo = repo, verbose = TRUE)
+  git("fetch", remote, branch)
 }
 
 #

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -141,7 +141,7 @@ git_worktree_setup <- function (path = ".", dest_dir, branch = "gh-pages", remot
     refspec <- make_refspec(remote, branch)
     cli::cat_line(glue::glue("refspec: {refspec}"))
     # git("fetch", "origin", refspec)
-    # gert::git_fetch(remote = remote, refspec = refspec, repo = path, verbose = TRUE)
+    gert::git_fetch(remote = remote, repo = path, verbose = TRUE)
     cli::cat_line("::endgroup::")
 
     ci_group(glue::glue("Add worktree for {remote}/{branch} in site/{fs::path_file(dest_dir)}"))

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -140,7 +140,8 @@ git_worktree_setup <- function (path = ".", dest_dir, branch = "gh-pages", remot
     # fetch the content of only the branch in question
     refspec <- make_refspec(remote, branch)
     cli::cat_line(glue::glue("refspec: {refspec}"))
-    gert::git_fetch(refspec = refspec, repo = path, verbose = TRUE)
+    # git("fetch", "origin", refspec)
+    # gert::git_fetch(remote = remote, refspec = refspec, repo = path, verbose = TRUE)
     cli::cat_line("::endgroup::")
 
     ci_group(glue::glue("Add worktree for {remote}/{branch} in site/{fs::path_file(dest_dir)}"))

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -140,8 +140,15 @@ git_worktree_setup <- function (path = ".", dest_dir, branch = "gh-pages", remot
     # fetch the content of only the branch in question
     refspec <- make_refspec(remote, branch)
     cli::cat_line(glue::glue("refspec: {refspec}"))
-    # git("fetch", "origin", refspec)
-    gert::git_fetch(remote = remote, repo = path, verbose = TRUE)
+    # We only want to fetch ONE branch and ONE branch, only. We apparently
+    # cannot do this by specifying a refspec for fetch, but we _can_ temporarily
+    # modify the refspec for for the repo.
+    # https://stackoverflow.com/a/62264058/2752888
+    git("remote", "set-branches", remote, branch)
+    git("fetch", remote, branch)
+    # https://stackoverflow.com/a/47726250/2752888
+    git("remote", "set-branches", remote, "*")
+    # gert::git_fetch(remote = remote, repo = path, verbose = TRUE)
     cli::cat_line("::endgroup::")
 
     ci_group(glue::glue("Add worktree for {remote}/{branch} in site/{fs::path_file(dest_dir)}"))

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -140,9 +140,10 @@ git_worktree_setup <- function (path = ".", dest_dir, branch = "gh-pages", remot
     # fetch the content of only the branch in question
     refspec <- make_refspec(remote, branch)
     cli::cat_line(glue::glue("refspec: {refspec}"))
-    # We only want to fetch ONE branch and ONE branch, only. We apparently
+    # NOTE: We only want to fetch ONE branch and ONE branch, only. We apparently
     # cannot do this by specifying a refspec for fetch, but we _can_ temporarily
     # modify the refspec for for the repo.
+    # Past Zhian saw this in {pkgdown}, but removed it for some reason :eyeroll:
     # https://stackoverflow.com/a/62264058/2752888
     git("remote", "set-branches", remote, branch)
     git("fetch", remote, branch)

--- a/tests/testthat/test-ci_deploy.R
+++ b/tests/testthat/test-ci_deploy.R
@@ -17,13 +17,17 @@ test_that("ci_deploy() will deploy once", {
   skip_if_not(has_git())
   skip_if_not(rmarkdown::pandoc_available("2.11"))
 
+  suppressMessages({
   out1 <- capture.output({
     ci_deploy(res, md_branch = "MD", site_branch = "SITE", remote = remote_name)
+  })
   })
   expected <- expand.grid(
     c("refs/heads", "refs/remotes/sandpaper-local"),
     c("main", "MD", "SITE")
   )
+  expect_true(any(grepl("::group::Add worktree for sandpaper-local/MD in site/built", out1)))
+  expect_true(any(grepl("::endgroup::", out1)))
   expected <- apply(expected, 1, paste, collapse = "/")
   expect_setequal(gert::git_info(res)$reflist, expected)
   md_log   <- gert::git_log("MD", repo = res)
@@ -63,21 +67,5 @@ test_that("ci_deploy() will fetch sources from upstream", {
   md_log   <- gert::git_log("MD", repo = res)
   expect_equal(nrow(md_log), 2)
 
-})
-
-test_that("bundle_pr_artifacts() can record diffs", {
-
-  skip("still working on this test")
-
-  withr::with_dir(res, {
-    # built worktree
-    del_md <- git_worktree_setup(res, fs::path(res, "site", "built"), 
-      branch = "MD", remote = remote_name
-    )
-    # ------------ site worktree
-    del_site <- git_worktree_setup(res, fs::path(res, "site", "docs"),
-      branch = "SITE", remote = remote_name
-    )
-  })
 })
 

--- a/tests/testthat/test-utils-git.R
+++ b/tests/testthat/test-utils-git.R
@@ -158,7 +158,7 @@ test_that("We can create worktrees from random branches", {
 })
 
 
-test_that("bundle_pr_artifacts() will bundle artifacts from a pr", {
+test_that("ci_bundle_pr_artifacts() will bundle artifacts from a pr", {
 
   gert::git_branch_checkout("landpaper-socal", repo = res)
   make_branch(repo = res, branch = "landpaper-norcal")


### PR DESCRIPTION
Fetching the orphan branches in a shallow clone requires you to fetch one and only one branch. As I documented in fb9966bcdbf23be13da166e2a9a10e14e329b0ef, I was finding issues with a disappearing remote, but this was because I never reset the refspec after I ran `git remote set-branches`. I thought that we could fetch using a specific refspec, but this appears not to be the case, so I've switched to this pattern, making sure to reset the remote after I've done. 
