### PR TITLE
Allow classless raw div elements 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9047
+Version: 0.0.0.9048
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9048
+
+BUG FIX
+-------
+
+* pandoc lua filter no longer errors on raw div HTML elements with no class
+  (@zkamvar, #166)
+
 # sandpaper 0.0.0.9047
 
 CONTINUOUS INTEGRATION

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -173,8 +173,12 @@ end
 function level_head(el, level)
 
   -- bail early if there is no class or it's not one of ours
+  local no_class = el.classes[1] == nil
+  if no_class then
+    return el
+  end
   local class = pandoc.utils.stringify(el.classes[1])
-  if class == nil or blocks[class] == nil then
+  if blocks[class] == nil then
     return el
   end
 

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -71,6 +71,18 @@ test_that("links are auto rendered", {
   expect_match(render_html(tmp), "href=", fixed = TRUE)
 })
 
+
+test_that("empty raw divs are still processed", {
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+  tmp <- fs::file_temp()
+  withr::local_file(tmp)
+  writeLines("<div>classless divs work</div>", tmp)
+  expect_match(render_html(tmp), "classless divs work", fixed = TRUE)
+
+})
+
+
 test_that("footnotes are rendered", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()


### PR DESCRIPTION
This fixes the bug in #165, which would be a problem for packages like {gt}, which generate HTML output. 