### PR TITLE
fix PR workflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9051
+Version: 0.0.0.9052
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # sandpaper 0.0.0.9051
 
+CONTINUOUS INTEGRATION
+----------------------
+
+* `pr-receive.yaml` has fixed spelling.
+* `pr-receive.yaml` has changed to short-cut the invalid PR messages and no
+  longer build the lesson if the PR is invalid. Instead, it will emit the same
+  warning message without building artifacts.
+
+DOCUMENTATION
+-------------
+
+* Documentation for test fixtures has been improved to include branch functions.
+
+# sandpaper 0.0.0.9051
+
 MISC
 ----
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ CONTINUOUS INTEGRATION
 * `pr-receive.yaml` has changed to short-cut the invalid PR messages and no
   longer build the lesson if the PR is invalid. Instead, it will emit the same
   warning message without building artifacts.
+* `pr-comment.yaml` will no longer fail when no artifacts exist (which would 
+  cause extraneous emails for users).
 
 DOCUMENTATION
 -------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# sandpaper 0.0.0.9051
+# sandpaper 0.0.0.9052
 
 CONTINUOUS INTEGRATION
 ----------------------

--- a/inst/workflows/pr-comment.yaml
+++ b/inst/workflows/pr-comment.yaml
@@ -143,5 +143,8 @@ jobs:
         uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.NR }} 
-          body: "Pull Request contains modified workflows; no preview will be created."
+          body: |
+            This pull request contains modified workflows and no preview will be created.
+
+            **Please inspect the changes for any malicious content.**
    

--- a/inst/workflows/pr-comment.yaml
+++ b/inst/workflows/pr-comment.yaml
@@ -9,14 +9,6 @@ on:
       - completed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print github context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
   # Pull requests are valid if:
   #  - they match the sha of the workflow run head commit
   #  - they are open
@@ -31,12 +23,14 @@ jobs:
       number: ${{ steps.get-pr.outputs.NUM }}
     steps:
       - name: 'Download PR artifact'
+        id: dl
         uses: carpentries/actions/download-workflow-artifact@main
         with:
           run: ${{ github.event.workflow_run.id }}
           name: 'pr'
 
       - name: "Get PR Number"
+        if: ${{ steps.dl.outputs.success == 'true' }}
         id: get-pr
         run: |
           unzip pr.zip
@@ -44,20 +38,11 @@ jobs:
       
       - name: "Check PR"
         id: check-pr
+        if: ${{ steps.dl.outputs.success == 'true' }}
         uses: carpentries/actions/check-valid-pr@main
         with:
           pr: ${{ steps.get-pr.outputs.NUM }}
           sha: ${{ github.events.workflow_run.head_commit.sha }}
-
-  show-outputs:
-    name: "Show Outputs"
-    runs-on: ubuntu-latest
-    needs: test-pr
-    steps:
-      - run: |
-          echo ${{ needs.test-pr.outputs.is_valid }}
-          echo ${{ needs.test-pr.outputs.number }}
-          echo ${{ needs.test-pr.outputs.payload }}
 
   # Create an orphan branch on this repository with two commits
   #  - the current HEAD of the md-outputs branch
@@ -79,14 +64,17 @@ jobs:
           fetch-depth: 1
 
       - name: 'Download built markdown'
+        id: dl
         uses: carpentries/actions/download-workflow-artifact@main
         with:
           run: ${{ github.event.workflow_run.id }}
           name: 'built'
 
-      - run: unzip built.zip
+      - if: ${{ steps.dl.output.success == 'true' }}
+        run: unzip built.zip
 
       - name: "Create orphan and push"
+        if: ${{ steps.dl.output.success == 'true' }}
         run: |
           cd built/
           git config --local user.email "actions@github.com"
@@ -113,15 +101,18 @@ jobs:
       NR: ${{ needs.test-pr.outputs.number }}
     steps:
       - name: 'Download comment artifact'
+        id: dl
         uses: carpentries/actions/download-workflow-artifact@main
         with:
           run: ${{ github.event.workflow_run.id }}
           name: 'diff'
           
-      - run: unzip ${{ github.workspace }}/diff.zip
+      - if: ${{ steps.dl.output.success == 'true' }}
+        run: unzip ${{ github.workspace }}/diff.zip
 
       - name: "Comment on PR"
         id: comment-diff
+        if: ${{ steps.dl.output.success == 'true' }}
         uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.NR }} 
@@ -130,10 +121,10 @@ jobs:
   # Comment if the PR is open and matches the SHA, but the workflow files have
   # changed
   comment-changed-workflow:
-    name: "Comment Changed Workflow"
+    name: "Comment if workflow files have changed"
     needs: test-pr
     runs-on: ubuntu-latest
-    if: ${{ needs.test-pr.outputs.is_valid != 'true' }}
+    if: ${{ needs.test-pr.outputs.is_valid == 'false' }}
     env:
       NR: ${{ needs.test-pr.outputs.number }}
     steps:

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -6,10 +6,24 @@ on:
       [opened, synchronize, reopened]
 
 jobs:
+  test-pr:
+    name: "Test if pull request is valid"
+    if ${{ github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    outputs:
+      is_valid: ${{ steps.check-pr.outputs.VALID }}
+    steps:
+      - name: "Check PR"
+        id: check-pr
+        uses: carpentries/actions/check-valid-pr@main
+        with:
+          pr: ${{ github.event.number }}
+
   build-md-source:
     name: "Build Markdown Source Files"
+    needs: test-pr
     runs-on: macOS-latest
-    if: ${{ github.event.action != 'closed' }}
+    if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/Library/Application Support/renv
@@ -140,3 +154,16 @@ jobs:
       - name: "Teardown"
         run: sandpaper::reset_site()
         shell: Rscript {0}
+
+  comment-changed-workflow:
+    name: "Comment Changed Workflow"
+    needs: test-pr
+    runs-on: ubuntu-latest
+    if: ${{ needs.test-pr.outputs.is_valid != 'true' }}
+    steps:
+      - name: "Comment on PR"
+        id: comment-diff
+        uses: carpentries/actions/comment-diff@main
+        with:
+          pr: ${{ github.workflow.number }} 
+          body: "Pull Request contains modified workflows; no preview will be created."

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-pr:
     name: "Test if pull request is valid"
-    if ${{ github.event.action != 'closed' }}
+    if: ${{ github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     outputs:
       is_valid: ${{ steps.check-pr.outputs.VALID }}
@@ -20,7 +20,7 @@ jobs:
           pr: ${{ github.event.number }}
 
   build-md-source:
-    name: "Build Markdown Source Files"
+    name: "Build markdown source files"
     needs: test-pr
     runs-on: macOS-latest
     if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
@@ -156,7 +156,7 @@ jobs:
         shell: Rscript {0}
 
   comment-changed-workflow:
-    name: "Comment Changed Workflow"
+    name: "Comment if workflow files have changed"
     needs: test-pr
     runs-on: ubuntu-latest
     if: ${{ needs.test-pr.outputs.is_valid != 'true' }}
@@ -165,5 +165,8 @@ jobs:
         id: comment-diff
         uses: carpentries/actions/comment-diff@main
         with:
-          pr: ${{ github.workflow.number }} 
-          body: "Pull Request contains modified workflows; no preview will be created."
+          pr: ${{ github.event.number }} 
+          body: |
+            This pull request contains modified workflows and no preview will be created.
+
+            Unless these changes come from a trusted source, please inspect the changes for any malicious content.

--- a/man/fixtures.Rd
+++ b/man/fixtures.Rd
@@ -4,12 +4,14 @@
 \alias{create_test_lesson}
 \alias{generate_restore_fixture}
 \alias{setup_local_remote}
+\alias{make_branch}
+\alias{clean_branch}
 \alias{remove_local_remote}
 \title{Test fixture functions for sandpaper}
 \usage{
 create_test_lesson()
 
-generate_restore_fixture(tf)
+generate_restore_fixture(repo)
 
 setup_local_remote(
   repo,
@@ -18,11 +20,13 @@ setup_local_remote(
   verbose = FALSE
 )
 
+make_branch(repo, branch = NULL, name = "sandpaper-local", verbose = FALSE)
+
+clean_branch(repo, branch = NULL, name = "sandpaper-local", verbose = FALSE)
+
 remove_local_remote(repo, name = "sandpaper-local")
 }
 \arguments{
-\item{tf}{(\code{generate_restore_fixture()}) the path to the test fixture lesson}
-
 \item{repo}{path to a git repository}
 
 \item{remote}{path to an empty or uninitialized directory. Defaults to a
@@ -32,6 +36,8 @@ tempfile}
 
 \item{verbose}{if \code{TRUE}, messages and output from git will be printed to
 screen. Defaults to \code{FALSE}.}
+
+\item{branch}{the name of the new branch to be deleted}
 }
 \value{
 (\code{generate_restore_fixture}) a function that will restore the test fixture
@@ -42,28 +48,40 @@ screen. Defaults to \code{FALSE}.}
 indicating the path to the remote
 }
 \description{
-These functions are for use during testing of {sandpaper} and are designed to
-create a temporary lesson and associated remote repository (locally).
+This suite of functions are for use during testing of {sandpaper} and are
+designed to create/work with a temporary lesson and associated remote
+repository (locally) that persists throughout the test suite. These functions
+are used in \code{tests/testthat/setup.R}. For more information, see the \href{https://testthat.r-lib.org/articles/test-fixtures.html#package}{package scope section of testthat article on Test Fixtures}.
 }
 \details{
-\subsection{create_test_lesson()}{
+\subsection{\code{create_test_lesson()}}{
 
-This creates the test lesson and returns a function that will restore the
-test fixture when called with no arguments
+This creates the test lesson and calls \code{generate_restore_fixture()} with the
+path of the new test lesson.
 }
 
-\subsection{generate_restore_fixture()}{
+\subsection{\code{generate_restore_fixture()}}{
 
-This creates the restore function for the test lesson
+This creates a function that will restore a lesson to its previous commit.
 }
 
-\subsection{setup_local_remote()}{
+\subsection{\code{setup_local_remote()}}{
 
 Creates a local remote repository in a separate temporary folder, linked to
-the fixture lesson
+the fixture lesson.
 }
 
-\subsection{remove_local_remote()}{
+\subsection{\code{make_branch()}}{
+
+create a branch in the local repository and push it to the remote repository.
+}
+
+\subsection{\code{clean_branch()}}{
+
+delete a branch in the local and remote repository.
+}
+
+\subsection{\code{remove_local_remote()}}{
 
 Destorys the local remote repository and removes it from the fixture lesson
 }


### PR DESCRIPTION
This updates the PR workflow to do a couple of things to help protect against malicious changes:

1. It checks the pr for validity in the pr-receive workflow
2. the action has been updated to fail if both workflows and content have been modified.
3. the commenting workflow will not fail if there are missing artifacts

I have also updated the documentation for some of the test fixtures.