### PR TITLE
skip pandoc devel structure tests; fix pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -72,6 +72,7 @@ reference:
    desc: >
      Tools for discovering resources and managing their hashes in a text file
      database.
+ - contents:
    - build_status
    - get_built_db
    - get_hash

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -106,8 +106,12 @@ test_that("pandoc structure is rendered correctly", {
   writeLines(ex, tmp)
   args <- construct_pandoc_args(tmp, out, to = "native")
   callr::r(function(...) rmarkdown::pandoc_convert(...), args = args)
+  if (.Platform$OS.type == "windows" && Sys.getenv("CI", unset = '') == "true") {
+    # let's see what this looks like
+    message(cat(readLines(out), sep = "\n"))
+  }
+  skip_on_os("windows")
   expect_snapshot(cat(readLines(out), sep = "\n"))
-
 })
 
 test_that("paragraphs after objectives block are parsed correctly", {
@@ -121,6 +125,11 @@ test_that("paragraphs after objectives block are parsed correctly", {
   writeLines(ex2, tmp)
   args <- construct_pandoc_args(tmp, out, to = "native")
   callr::r(function(...) rmarkdown::pandoc_convert(...), args = args)
+  if (.Platform$OS.type == "windows" && Sys.getenv("CI", unset = '') == "true") {
+    # let's see what this looks like
+    message(cat(readLines(out), sep = "\n"))
+  }
+  skip_on_os("windows")
   expect_snapshot(cat(readLines(out), sep = "\n"))
 
 })


### PR DESCRIPTION
Windows tests on CI uses the devel version of pandoc, which can change in unexpected ways, It failed this morning because pandoc devel emits its raw output by element instead of by block (I believe).

This also fixes a pkgdown flub