### PR TITLE
Run hydrate politely

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9053
+Version: 0.0.0.9054
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9054
+
+MISC
+----
+
+* `manage_deps()` runs slightly faster now that it no longer runs
+  `renv::hydrate()` if no new packages have been added in the lesson.
+
 # sandpaper 0.0.0.9053
 
 NEW FEATURES

--- a/R/manage_deps.R
+++ b/R/manage_deps.R
@@ -83,7 +83,7 @@ manage_deps <- function(path = ".", profile = "lesson-requirements", snapshot = 
   )
 
   sho <- !(quiet || identical(Sys.getenv("TESTTHAT"), "true"))
-  callr::r(
+  res <- callr::r(
     func = callr_manage_deps,
     args = args,
     show = !quiet,
@@ -94,6 +94,7 @@ manage_deps <- function(path = ".", profile = "lesson-requirements", snapshot = 
       "R_PROFILE_USER" = fs::path(tempfile(), "nada"),
       "RENV_CONFIG_CACHE_SYMLINKS" = renv_cache_available())
   )
+  invisible(res)
 }
 
 #' Fetch updates for Package Cache

--- a/R/utils-callr.R
+++ b/R/utils-callr.R
@@ -85,7 +85,7 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
     # if there _is_ a lockfile, we only want to hydrate new packages that do not
     # previously exist in the library, because 
     installed <- installed.packages(lib.loc = renv::paths$library())[, "Package"]
-    deps <- renv::dependencies(root = path)$Packages
+    deps <- unique(renv::dependencies(root = path)$Packages)
     pkgs <- setdiff(deps, installed)
     needs_hydration <- length(pkgs) > 0
   } else {
@@ -94,7 +94,7 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
   }
   if (needs_hydration) {
     hydra <- renv::hydrate(packages = pkgs,
-      library = renv::paths$library(), 
+      library = renv::paths$library(),
       update = FALSE
     )
   }
@@ -102,7 +102,7 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
   #    recorded.
   if (lockfile_exists) {
     cli::cli_alert("Restoring any dependency versions")
-    res <- renv::restore(library = renv::paths$library(), 
+    res <- renv::restore(library = renv::paths$library(),
       lockfile = renv::paths$lockfile(),
       prompt = FALSE
     )

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -70,7 +70,7 @@ test_that("manage_deps() will run without callr", {
     snapshot = TRUE, 
     lockfile_exists = TRUE) %>%
     expect_message("Restoring any dependency versions") %>%
-    expect_output("Copying packages into the library")
+    expect_output("Finding R package dependencies")
   })
 
 

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -70,7 +70,7 @@ test_that("manage_deps() will run without callr", {
     snapshot = TRUE, 
     lockfile_exists = TRUE) %>%
     expect_message("Restoring any dependency versions") %>%
-    expect_output("Finding R package dependencies")
+    expect_output("package dependencies")
   })
 
 
@@ -107,10 +107,6 @@ test_that("pin_version() will use_specific versions", {
   
   skip_on_os("windows")
   skip_if_offline()
-  writeLines("library(sessioninfo)", con = fs::path(lsn, "episodes", "si.R"))
-  expect_output({
-    pin_version("sessioninfo@1.1.0", path = lsn) # old version of sessioninfo
-  }, "Updated 1 record in")
 
   withr::local_envvar(list(
     "RENV_PROFILE" = "lesson-requirements",
@@ -118,11 +114,18 @@ test_that("pin_version() will use_specific versions", {
     "RENV_CONFIG_CACHE_SYMLINKS" = renv_cache_available()
   ))
 
+  writeLines("library(sessioninfo)", con = fs::path(lsn, "episodes", "si.R"))
+  expect_output({
+    pin_version("sessioninfo@1.1.0", path = lsn) # old version of sessioninfo
+  }, "Updated 1 record in")
+
+
   suppressMessages({
   res <- callr_manage_deps(lsn, 
     repos = renv_carpentries_repos(), 
-    snapshot = TRUE, 
-    lockfile_exists = TRUE) %>%
+    snapshot = TRUE,
+    lockfile_exists = TRUE,
+    in_covr = covr::in_covr()) %>%
     expect_message("Restoring any dependency versions") %>%
     expect_output("sessioninfo")
   })


### PR DESCRIPTION
This will _slightly_ speed up the pre-flight cache preparation procedures for lessons by only running `renv::hydrate()` if packages have been added to the lesson or if there is no lockfile. 