### PR TITLE
Fix monthly workflow to run only once

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release', cache: '~/Library/Application Support/renv', cov: 'true'}
+          - {os: macOS-11,   r: 'release', cache: '~/Library/Application Support/renv', cov: 'true'}
           - {os: windows-latest, r: 'release', cache: '~\AppData\Local\renv
 '}
           - {os: ubuntu-18.04,   r: 'devel', cache: '~/.local/share/renv', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9058
+Version: 0.0.0.9059
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# sandpaper 0.0.0.9059
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* The scheduler for `update-cache.yaml` has been fixed to run strictly on the
+  first Tuesday of the month instead of the first seven days of the month AND on
+  Tuesdays. It also gains the ability to set the day of the month with a
+  repository-specific `CACHE_DAY` secret specifying the ISO (`+%w`) day of the
+  week (0-6, with 0 being Sunday).
+
 # sandpaper 0.0.0.9058
 
 CONTINUOUS INTEGRATION

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,7 @@ CONTINUOUS INTEGRATION
 
 * The scheduler for `update-cache.yaml` has been fixed to run strictly on the
   first Tuesday of the month instead of the first seven days of the month AND on
-  Tuesdays. It also gains the ability to set the day of the month with a
-  repository-specific `CACHE_DAY` secret specifying the ISO (`+%w`) day of the
-  week (0-6, with 0 being Sunday).
+  Tuesdays.
 
 # sandpaper 0.0.0.9058
 

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -22,7 +22,7 @@ jobs:
   build-md-source:
     name: "Build markdown source files"
     needs: test-pr
-    runs-on: macOS-latest
+    runs-on: macOS-11
     if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: macOS-latest
+    runs-on: macOS-11
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/Library/Application Support/renv

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -84,7 +84,7 @@ jobs:
     name: "Update Package Cache"
     needs: check_token
     if: ${{ needs.check_token.outputs.repo== 'true' }}
-    runs-on: macOS-latest
+    runs-on: macOS-11
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/Library/Application Support/renv

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -8,13 +8,32 @@ on:
         required: true
         default: 'monthly run'
   schedule:
-    # Run first tuesday of the month
-    - cron: '0 0 1-7 * 2'
+    # Run the first through seventh day, control the day through the secrets
+    - cron: '0 0 1-7 * *'
 
 jobs:
+  check_date:
+    name: "Check the day"
+    runs-on: ubuntu-lates
+    outputs:
+      ok: ${{ steps.check.outputs.ok }}
+    steps:
+      - id: check
+        run: |
+          runday=${{ secrets.CACHE_DAY }}
+          runday=$( [[ -e ${runday} ]] && echo ${runday} || echo 2 )
+          if [[ `date +%w` -eq ${runday} ]]; then
+            echo "::set-output name=ok::true"
+          else
+            echo "::set-output name=ok::false"
+            echo "not today"
+          fi
+
   check_renv:
     name: "Check if We Need {renv}"
     runs-on: ubuntu-latest
+    needs: check_date
+    if: ${{ needs.check_date.outputs.ok }}
     outputs:
       needed: ${{ steps.renv.outputs.exists }}
     steps:

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   check_date:
     name: "Check the day"
-    runs-on: ubuntu-lates
+    runs-on: ubuntu-latest
     outputs:
       ok: ${{ steps.check.outputs.ok }}
     steps:
@@ -33,7 +33,7 @@ jobs:
     name: "Check if We Need {renv}"
     runs-on: ubuntu-latest
     needs: check_date
-    if: ${{ needs.check_date.outputs.ok }}
+    if: ${{ needs.check_date.outputs.ok == 'true'}}
     outputs:
       needed: ${{ steps.renv.outputs.exists }}
     steps:

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -8,8 +8,8 @@ on:
         required: true
         default: 'monthly run'
   schedule:
-    # Run the first through seventh day, control the day through the secrets
-    - cron: '0 0 1-7 * *'
+    # Run every tuesday
+    - cron: '0 0 * * 2'
 
 jobs:
   check_date:
@@ -23,7 +23,8 @@ jobs:
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "::set-output name=ok::true"
             echo "Running on request"
-          elif [[ `date +%w` -eq 2 ]]; then
+          elif [[ `date +%d` -le 7 ]]; then
+            # If the Tuesday lands in the first week of the month, run it
             echo "::set-output name=ok::true"
             echo "Running on schedule"
           else

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -20,9 +20,7 @@ jobs:
     steps:
       - id: check
         run: |
-          runday=${{ secrets.CACHE_DAY }}
-          runday=$( [[ -e ${runday} ]] && echo ${runday} || echo 2 )
-          if [[ `date +%w` -eq ${runday} ]]; then
+          if [[ `date +%w` -eq 2 ]]; then
             echo "::set-output name=ok::true"
           else
             echo "::set-output name=ok::false"

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * 2'
 
 jobs:
-  check_date:
+  preflight:
     name: "Preflight Check"
     runs-on: ubuntu-latest
     outputs:
@@ -35,8 +35,8 @@ jobs:
   check_renv:
     name: "Check if We Need {renv}"
     runs-on: ubuntu-latest
-    needs: check_date
-    if: ${{ needs.check_date.outputs.ok == 'true'}}
+    needs: preflight
+    if: ${{ needs.preflight.outputs.ok == 'true'}}
     outputs:
       needed: ${{ steps.renv.outputs.exists }}
     steps:

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -13,18 +13,22 @@ on:
 
 jobs:
   check_date:
-    name: "Check the day"
+    name: "Preflight Check"
     runs-on: ubuntu-latest
     outputs:
       ok: ${{ steps.check.outputs.ok }}
     steps:
       - id: check
         run: |
-          if [[ `date +%w` -eq 2 ]]; then
+          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "::set-output name=ok::true"
+            echo "Running on request"
+          elif [[ `date +%w` -eq 2 ]]; then
+            echo "::set-output name=ok::true"
+            echo "Running on schedule"
           else
             echo "::set-output name=ok::false"
-            echo "not today"
+            echo "Not Running Today"
           fi
 
   check_renv:


### PR DESCRIPTION
It turns out that a workflow scheduled to run monthly ran every day for the first seven days of the month AND on Tuesdays. 

This changes the workflow to run weekly on Tuesdays, but it will check that the Tuesday is within the first seven days of the month. 