### PR TITLE
use name var for lesson title

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9061
+Version: 0.0.0.9062
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.0.0.9062
+
+BUG FIX
+-------
+
+* New lessons that specify custom titles will have them reflected in the config
+  file (@zkamvar, #195).
+
 # sandpaper 0.0.0.9061
 
 BUG FIX

--- a/R/create_lesson.R
+++ b/R/create_lesson.R
@@ -46,7 +46,7 @@ create_lesson <- function(path, name = fs::path_file(path), rstudio = rstudioapi
   account <- tryCatch(gh::gh_whoami()$login, error = function(e) "carpentries")
   copy_template("config", path, "config.yaml",
     values = list(
-      title      = "Lesson Title",
+      title      = if (is.null(match.call()$name)) "Lesson Title" else siQuote(name),
       carpentry  = "cp",
       life_cycle = "pre-alpha",
       license    = "CC-BY 4.0",

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -11,7 +11,7 @@ test_that("lessons can be created in empty directories", {
 
   expect_false(fs::dir_exists(tmp))
   suppressMessages({expect_message({
-    res <- create_lesson(tmp, rstudio = TRUE, open = TRUE)
+    res <- create_lesson(tmp, name = "BRAND NEW LESSON", rstudio = TRUE, open = TRUE)
   }, "Setting active project to")})
   tmp <- normalizePath(tmp)
   expect_false(wd == fs::path(normalizePath(getwd())))
@@ -47,7 +47,7 @@ test_that("All template files exist", {
   expect_true(fs::dir_exists(fs::path(tmp, "learners")))
   expect_true(fs::dir_exists(fs::path(tmp, "profiles")))
   expect_true(fs::file_exists(fs::path(tmp, "README.md")))
-  expect_match(readLines(fs::path(tmp, "README.md"))[1], "lesson-init-example", fixed = TRUE) 
+  expect_match(readLines(fs::path(tmp, "README.md"))[1], "BRAND NEW LESSON", fixed = TRUE) 
   expect_true(fs::file_exists(fs::path(tmp, "site", "README.md")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "DESCRIPTION")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "_pkgdown.yaml")))
@@ -67,6 +67,10 @@ test_that("Templated files are correct", {
     readLines(template_episode())
   )
   
+})
+
+test_that("Lesson title is correctly configured", {
+  expect_equal(get_config(tmp)$title, "BRAND NEW LESSON")
 })
 
 test_that("The site/ directory is ignored by git", {


### PR DESCRIPTION
This will fix #195

``` r
library(sandpaper)
tmp <- tempfile()
create_lesson(tmp, "2 Lesson: 2 Title", open = FALSE)
get_config(tmp)$title
#> [1] "2 Lesson: 2 Title"
```

<sup>Created on 2021-10-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>