### PR TITLE
update tests for cli 3.1.0

### DIFF
--- a/tests/testthat/_snaps/get_episode.md
+++ b/tests/testthat/_snaps/get_episode.md
@@ -13,8 +13,8 @@
       expect_error(set_episodes(res, bad, write = TRUE))
     Message <cliMessage>
       episodes:
-      - [34m[34m01-introduction.Rmd[34m[39m
-      - x [1m[1mI-do-not-exist.md[1m[22m
+      - [34m01-introduction.Rmd[39m
+      - x [1mI-do-not-exist.md[22m
 
 # set_episode() will throw an error if an episode does not exist [unicode]
 
@@ -31,8 +31,8 @@
       expect_error(set_episodes(res, bad, write = TRUE))
     Message <cliMessage>
       episodes:
-      - [34m[34m01-introduction.Rmd[34m[39m
-      - ✖ [1m[1mI-do-not-exist.md[1m[22m
+      - [34m01-introduction.Rmd[39m
+      - ✖ [1mI-do-not-exist.md[22m
 
 # get_episode() will throw a message about episode in draft [plain]
 
@@ -77,8 +77,8 @@
       expect_error(get_episodes(res))
     Message <cliMessage>
       episodes:
-      - [34m[34m01-introduction.Rmd[34m[39m
-      - x [1m[1mI-am-an-impostor.md[1m[22m
+      - [34m01-introduction.Rmd[39m
+      - x [1mI-am-an-impostor.md[22m
 
 # get_episode() will throw a warning if an episode in config does not exist [unicode]
 
@@ -95,6 +95,6 @@
       expect_error(get_episodes(res))
     Message <cliMessage>
       episodes:
-      - [34m[34m01-introduction.Rmd[34m[39m
-      - ✖ [1m[1mI-am-an-impostor.md[1m[22m
+      - [34m01-introduction.Rmd[39m
+      - ✖ [1mI-am-an-impostor.md[22m
 

--- a/tests/testthat/_snaps/manage_deps.md
+++ b/tests/testthat/_snaps/manage_deps.md
@@ -35,26 +35,26 @@
       cat(paste(c("1:", "2:"), sandpaper:::message_package_cache(msg)), sep = "\n")
     Message <cliMessage>
       
-      [36m--[39m [1m[1mCaching Build Packages for Generated Content[1m[22m [36m--------------------------------[39m
-      The Carpentries lesson infrastructure uses the [34m[34mrenv[34m[39m (R environment) package to[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39mmaintain reproducibility for lessons with generated content. It looks like you[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39mhave not yet used [34m[34mrenv[34m[39m before, so [1m[1mthis is a one-time message[1m[22m that gives you[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22minformation about how the package cache can help you with your lesson.[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47mrenv maintains a local cache of data on the filesystem, located at:[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m- "/path/to/cache"[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47mThis path can be customized: please see the documentation in `?renv::paths`.[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m> This may take some time to set up the first time you use it, but once the[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mcache is established, the process will run much more quickly.[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mIf you choose not to use the package cache, be aware that you may find[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mdifferences between the lesson you render on your computer and what is rendered[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39monline.[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1mDo you want to using a package cache for Carpentries lessons?[1m[22m
+      [36m--[39m [1mCaching Build Packages for Generated Content[22m [36m--------------------------------[39m
+      The Carpentries lesson infrastructure uses the [34mrenv[39m (R environment) package to
+      maintain reproducibility for lessons with generated content. It looks like you
+      have not yet used [34mrenv[39m before, so [1mthis is a one-time message[22m that gives you
+      information about how the package cache can help you with your lesson.
+      
+      [30m[47mrenv maintains a local cache of data on the filesystem, located at:[49m[39m
+      
+      - "/path/to/cache"
+      
+      This path can be customized: please see the documentation in `?renv::paths`.
+      
+      > This may take some time to set up the first time you use it, but once the
+      cache is established, the process will run much more quickly.
+      
+      If you choose not to use the package cache, be aware that you may find
+      differences between the lesson you render on your computer and what is rendered
+      online.
+      
+      [1mDo you want to using a package cache for Carpentries lessons?[22m
       -- Enter your selection or press 0 to exit -------------------------------------
     Output
       1: [1mYes[22m, please use the package cache (recommended)
@@ -97,26 +97,26 @@
       cat(paste(c("1:", "2:"), sandpaper:::message_package_cache(msg)), sep = "\n")
     Message <cliMessage>
       
-      [36m──[39m [1m[1mCaching Build Packages for Generated Content[1m[22m [36m────────────────────────────────[39m
-      The Carpentries lesson infrastructure uses the [34m[34mrenv[34m[39m (R environment) package to[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39mmaintain reproducibility for lessons with generated content. It looks like you[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39mhave not yet used [34m[34mrenv[34m[39m before, so [1m[1mthis is a one-time message[1m[22m that gives you[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22minformation about how the package cache can help you with your lesson.[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47mrenv maintains a local cache of data on the filesystem, located at:[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m- "/path/to/cache"[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47mThis path can be customized: please see the documentation in `?renv::paths`.[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m→ This may take some time to set up the first time you use it, but once the[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mcache is established, the process will run much more quickly.[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mIf you choose not to use the package cache, be aware that you may find[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39mdifferences between the lesson you render on your computer and what is rendered[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39monline.[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1m[1m[1m[1m[22m
-      [34m[34m[34m[39m[34m[34m[34m[39m[1m[1m[1m[22m[30m[47m[30m[47m[47m[30m[49m[39m[1m[1mDo you want to using a package cache for Carpentries lessons?[1m[22m
+      [36m──[39m [1mCaching Build Packages for Generated Content[22m [36m────────────────────────────────[39m
+      The Carpentries lesson infrastructure uses the [34mrenv[39m (R environment) package to
+      maintain reproducibility for lessons with generated content. It looks like you
+      have not yet used [34mrenv[39m before, so [1mthis is a one-time message[22m that gives you
+      information about how the package cache can help you with your lesson.
+      
+      [30m[47mrenv maintains a local cache of data on the filesystem, located at:[49m[39m
+      
+      - "/path/to/cache"
+      
+      This path can be customized: please see the documentation in `?renv::paths`.
+      
+      → This may take some time to set up the first time you use it, but once the
+      cache is established, the process will run much more quickly.
+      
+      If you choose not to use the package cache, be aware that you may find
+      differences between the lesson you render on your computer and what is rendered
+      online.
+      
+      [1mDo you want to using a package cache for Carpentries lessons?[22m
       ── Enter your selection or press 0 to exit ─────────────────────────────────────
     Output
       1: [1mYes[22m, please use the package cache (recommended)

--- a/tests/testthat/_snaps/update_workflows.md
+++ b/tests/testthat/_snaps/update_workflows.md
@@ -13,8 +13,8 @@
       update_github_workflows(tmp)
     Message <cliMessage>
       [36mi[39m Workflows/files updated:
-      - [34m[34m.github/workflows/deleteme.yaml[34m[39m [3m[3m(deleted)[3m[23m
-      - [34m[34m.github/workflows/sandpaper-main.yaml[34m[39m [3m[3m(new)[3m[23m
+      - [34m.github/workflows/deleteme.yaml[39m [3m(deleted)[23m
+      - [34m.github/workflows/sandpaper-main.yaml[39m [3m(new)[23m
 
 # github workflows can be fetched [unicode]
 
@@ -31,8 +31,8 @@
       update_github_workflows(tmp)
     Message <cliMessage>
       [36mℹ[39m Workflows/files updated:
-      - [34m[34m.github/workflows/deleteme.yaml[34m[39m [3m[3m(deleted)[3m[23m
-      - [34m[34m.github/workflows/sandpaper-main.yaml[34m[39m [3m[3m(new)[3m[23m
+      - [34m.github/workflows/deleteme.yaml[39m [3m(deleted)[23m
+      - [34m.github/workflows/sandpaper-main.yaml[39m [3m(new)[23m
 
 # github workflows can be updated [plain]
 
@@ -48,7 +48,7 @@
       update_github_workflows(tmp, "sandpaper-main.yaml")
     Message <cliMessage>
       [36mi[39m Workflows/files updated:
-      - [34m[34m.github/workflows/sandpaper-main.yaml[34m[39m [3m[3m(modified)[3m[23m
+      - [34m.github/workflows/sandpaper-main.yaml[39m [3m(modified)[23m
 
 # github workflows can be updated [unicode]
 
@@ -64,7 +64,7 @@
       update_github_workflows(tmp, "sandpaper-main.yaml")
     Message <cliMessage>
       [36mℹ[39m Workflows/files updated:
-      - [34m[34m.github/workflows/sandpaper-main.yaml[34m[39m [3m[3m(modified)[3m[23m
+      - [34m.github/workflows/sandpaper-main.yaml[39m [3m(modified)[23m
 
 # github workflows are recognized as up-to-date
 


### PR DESCRIPTION
the {cli} package has updated and luckily made its output a lot simpler! This fixes the snapshot tests for it.