### PR TITLE
Update workflows to use ubuntu

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9067
+Version: 0.0.0.9068
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# sandpaper 0.0.0.9068
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* Workflows have been updated to use `ubuntu-latest` instead of `macOS-11`.
+  The macOS runners were often ~ 1 minute faster than the ubuntu runners, but
+  the tradeoff was potential failures when packages were not available as
+  binary versions and would need compilation with external C libraries (along
+  with runs failing due to brew timeouts). This update coincides with an update
+  for the github actions, which will now check and install the ubuntu
+  dependencies before updating/installing packages. (@zkamvar, #184)
+
 # sandpaper 0.0.0.9067
 
 BUG FIX

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -22,11 +22,11 @@ jobs:
   build-md-source:
     name: "Build markdown source files"
     needs: test-pr
-    runs-on: macOS-11
+    runs-on: ubuntu-latest
     if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RENV_PATHS_ROOT: ~/Library/Application Support/renv
+      RENV_PATHS_ROOT: ~/.local/share/renv/
       CHIVE: ${{ github.workspace }}/site/chive
       PR: ${{ github.workspace }}/site/pr
       MD: ${{ github.workspace }}/site/built

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -20,10 +20,10 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: macOS-11
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RENV_PATHS_ROOT: ~/Library/Application Support/renv
+      RENV_PATHS_ROOT: ~/.local/share/renv/
     steps:
 
       - name: "Checkout Lesson"
@@ -31,6 +31,8 @@ jobs:
 
       - name: "Set up R"
         uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
 
       - name: "Set up Pandoc"
         uses: r-lib/actions/setup-pandoc@v1

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -84,10 +84,10 @@ jobs:
     name: "Update Package Cache"
     needs: check_token
     if: ${{ needs.check_token.outputs.repo== 'true' }}
-    runs-on: macOS-11
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RENV_PATHS_ROOT: ~/Library/Application Support/renv
+      RENV_PATHS_ROOT: ~/.local/share/renv/
     steps:
 
       - name: "Checkout Lesson"


### PR DESCRIPTION
This will fix #184

Workflows have been updated to use `ubuntu-latest` instead of `macOS-11`. The macOS runners were often ~ 1 minute faster than the ubuntu runners, but the tradeoff was potential failures when packages were not available as binary versions and would need compilation with external C libraries (along with runs failing due to brew timeouts). This update coincides with an update for the github actions, which will now check and install the ubuntu dependencies before updating/installing packages.