### PR TITLE
preserve tabs in code blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # sandpaper 0.1.0
 
+BUG FIXES
+---------
+
+* `render_html()` now passes the `--preserve-tabs` parameter to prevent pandoc
+  from removing educationally relevant information from the lessons.
+
 BREAKING CHANGES
 ----------------
 

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -75,6 +75,7 @@ construct_pandoc_args <- function(path_in, output, to = "html", ...) {
     from    = from,
     to      = to,
     options = c(
+      "--preserve-tabs",
       "--indented-code-classes=sh", 
       "--section-divs", 
       "--mathjax",

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -1,6 +1,15 @@
 example_markdown <- fs::path_abs(test_path("examples", "ex.md"))
 
 
+test_that("tabs are preserved", {
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+  tmp <- fs::file_temp()
+  withr::local_file(tmp)
+  writeLines("```python\nfor i in range(3):\n\tprint(i)\n\n```\n", tmp)
+  expect_match(render_html(tmp), "\t")
+})
+
+
 test_that("emoji are rendered", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()


### PR DESCRIPTION
This preserves tabs in code blocks so that the python lessons do not confuse learners. 