### PR TITLE
add mechanism for cleaning up detritus in site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ BUG FIXES
 * the internal function `render_html()` now passes the `--preserve-tabs`
   parameter to prevent pandoc from removing educationally relevant information
   from the lessons.
+* when rebuilding a lesson with `ci_deploy(..., rebuild = TRUE)`, detritus in
+  the lesson site will be cleaned (@zkamvar, #91).
 
 BREAKING CHANGES
 ----------------

--- a/R/ci_build_site.R
+++ b/R/ci_build_site.R
@@ -4,6 +4,8 @@
 #' @param branch the branch name that contains the full HTML site
 #' @param md the branch name that contains the markdown outputs
 #' @param remote the name of the git remote to which you should deploy.
+#' @param reset if `TRUE`, the contents of the branch/folder will be cleared
+#'   before inserting new items
 #' @return NOTHING
 #'
 #' @note this function is not for interactive use. It requires git to be
@@ -13,7 +15,7 @@
 #'   package cache.
 #'
 #' @keywords internal
-ci_build_site <- function(path = ".", branch = "gh-pages", md = "md-outputs", remote = "origin") {
+ci_build_site <- function(path = ".", branch = "gh-pages", md = "md-outputs", remote = "origin", reset = FALSE) {
 
   # step 0: build_lesson defaults to a local build
   path <- set_source_path(path)
@@ -47,6 +49,12 @@ ci_build_site <- function(path = ".", branch = "gh-pages", md = "md-outputs", re
 
     # remove the worktree at the end since this is the last step
     on.exit(eval(del_site), add = TRUE)
+
+    if (reset) {
+      ci_group("Reset Site")
+      git_clean_everything(html)
+      cli::cat_line("::endgroup::")
+    }
 
     # Build the site quickly using the markdown files as-is
     ci_group("Build Lesson Website")

--- a/R/ci_deploy.R
+++ b/R/ci_deploy.R
@@ -27,7 +27,7 @@ ci_deploy <- function(path = ".", md_branch = "md-outputs", site_branch = "gh-pa
   on.exit(eval(del_md), add = TRUE)
 
   # Step 2: build the site from the source files
-  ci_build_site(path, branch = site_branch, md = md_branch, remote = remote)
+  ci_build_site(path, branch = site_branch, md = md_branch, remote = remote, reset = reset)
 
   invisible()
 }

--- a/R/utils-store.R
+++ b/R/utils-store.R
@@ -42,7 +42,6 @@ clear_this_lesson <- function() .store$clear()
 this_lesson <- function(path) {
   if (.store$valid(path)) .store$get() else .store$set(path)
 }
-
 .lesson_store <- function() {
   .this_diff <- NULL
   .this_status <- NULL
@@ -68,5 +67,6 @@ this_lesson <- function(path) {
     }
   )
 }
+#nocov start
 .store <- .lesson_store()
-
+#nocov end

--- a/man/ci_build_site.Rd
+++ b/man/ci_build_site.Rd
@@ -8,7 +8,8 @@ ci_build_site(
   path = ".",
   branch = "gh-pages",
   md = "md-outputs",
-  remote = "origin"
+  remote = "origin",
+  reset = FALSE
 )
 }
 \arguments{
@@ -19,6 +20,9 @@ ci_build_site(
 \item{md}{the branch name that contains the markdown outputs}
 
 \item{remote}{the name of the git remote to which you should deploy.}
+
+\item{reset}{if \code{TRUE}, the contents of the branch/folder will be cleared
+before inserting new items}
 }
 \value{
 NOTHING

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -6,7 +6,7 @@
 \alias{sandpaper-package}
 \title{sandpaper: Create and Curate Carpentries Lessons}
 \description{
-Boilerplate directory structure, build tools, and hosting tools for your lesson.
+We provide tools to build a Carpentries-themed lesson repository into an accessible standalone static website. These include local tools and those designed to be used in a continuous integration context so that all the lesson author needs to focus on is writing the content of the actual lesson.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-ci_deploy_site.R
+++ b/tests/testthat/test-ci_deploy_site.R
@@ -1,3 +1,0 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
-})

--- a/tests/testthat/test-utils-store.R
+++ b/tests/testthat/test-utils-store.R
@@ -1,0 +1,23 @@
+res <- restore_fixture()
+nossel_store <- .lesson_store()
+
+test_that("lesson store can be independently created", {
+  expect_type(nossel_store, "list")
+  expect_named(nossel_store, c("get", "valid", "set", "clear"))
+})
+
+test_that("lesson store starts off as NULL", {
+  expect_null(nossel_store$get())
+})
+
+test_that("lesson store can be set and returns a lesson", {
+  nossel_store$set(res)
+  expect_s3_class(nossel_store$get(), "Lesson")
+  expect_true(nossel_store$valid(res))
+})
+
+test_that("lesson store can be cleared", {
+  nossel_store$clear()
+  expect_null(nossel_store$get())
+})
+


### PR DESCRIPTION
This addresses #91 for the deployment when `reset = TRUE` (which must be manually triggered on markdown sites). 
