### PR TITLE
Update metadata; bump pegboard; bump to 0.1.1

### DIFF
--- a/.github/workflows/update-dots.yaml
+++ b/.github/workflows/update-dots.yaml
@@ -25,4 +25,4 @@ jobs:
           git config --local user.name "GitHub Actions"
           git add vignettes/articles/img/*.svg
           git commit -m "[actions] update images" || echo "nothing to commit"
-          git push
+          git push || echo "nothing to push"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: We provide tools to build a Carpentries-themed lesson repository
 License: MIT + file LICENSE
 Imports: 
     pkgdown (>= 1.6.0),
-    pegboard (>= 0.0.0.9024),
+    pegboard (>= 0.1.0),
     cli (>= 2.0.2),
     commonmark,
     fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@ METADATA
 --------
 
  * The metadata included in the lesson footer now correctly states the `@type`
-   as `TrainingMaterial`.
+   as `TrainingMaterial` (@zkamvar, #236)
+ * A basic sitemap is now constructed for the lesson (@zkamvar, #243)
 
 # sandpaper 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# sandpaper 0.1.1
+
+DEPENDENCIES
+------------
+
+* The {pegboard} package is now required to be 0.1.0 or greater due to a fix for
+  generating the keypoints page (https://github.com/carpentries/pegboard/pull/76)
+
+METADATA
+--------
+
+ * The metadata included in the lesson footer now correctly states the `@type`
+   as `TrainingMaterial`.
+
 # sandpaper 0.1.0
 
 BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,12 @@ METADATA
    as `TrainingMaterial` (@zkamvar, #236)
  * A basic sitemap is now constructed for the lesson (@zkamvar, #243)
 
+BUG FIX
+-------
+
+ * Empty pages will no longer throw errors in rendering and they will not be
+   included in the output (@zkamvar, #237)
+
 # sandpaper 0.1.0
 
 BUG FIXES

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -66,6 +66,10 @@ build_episode_html <- function(path_md, path_src = NULL,
                                sidebar = NULL, date = NULL) {
   home <- root_path(path_md)
   body <- render_html(path_md, quiet = quiet)
+  if (body == "") {
+    # if there is nothing in the page then we build nothing.
+    return(NULL)
+  }
   nodes <- xml2::read_html(body)
   fix_nodes(nodes)
   yaml <- yaml::yaml.load(politely_get_yaml(path_md), eval.expr = FALSE)

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -79,6 +79,8 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
     next_page = abs_md[er[1]]
   )
 
+  build_sitemap(pkg$dst_path, quiet = quiet)
+
   pkgdown::preview_site(pkg, "/", preview = preview)
 
   if (!quiet) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,6 +23,26 @@ make_github_url <- function(path) {
   paste0("https://", res[1], ".github.io/", res[2])
 }
 
+build_sitemap <- function(out, quiet = TRUE) {
+  if (!quiet) cli::cli_rule(cli::style_bold("Creating sitemap.xml"))
+  url <- this_metadata$get()$url
+  paths <- fs::dir_ls(out, glob = "*.html", recurse = TRUE)
+  urls <- paste0(url, fs::path_rel(paths, out))
+  doc <- urls_to_sitemap(urls)
+  sitemap <- fs::path(out, "sitemap.xml")
+  xml2::write_xml(doc, file = sitemap)
+  invisible()
+}
+
+urls_to_sitemap <- function(urls) {
+  doc <- xml2::read_xml("<urlset xml2ns='http://www.sitemaps.org/schemas/sitemap/0.9'></urlset>")
+  for (url in urls) {
+    child <- xml2::read_xml(paste0("<url><loc>", url, "</loc></url>"))
+    xml2::xml_add_child(doc, child)
+  }
+  doc
+}
+
 get_trimmed_title <- function(next_page) {
   next_page <- get_navbar_info(next_page)
   if (is.null(next_page$pagetitle)) {

--- a/inst/templates/metadata-template.txt
+++ b/inst/templates/metadata-template.txt
@@ -1,7 +1,7 @@
 {{=<% %>=}}
 {
   "@context": "https://schema.org",
-  "@type": "LearningResource",
+  "@type": "TrainingMaterial",
   "@id": "<% url %>",
   "dct:conformsTo": "https://bioschemas.org/profiles/TrainingMaterial/0.9-DRAFT-2020_12_08",
   "description": "<% desc %><% ^desc %>A Carpentries Lesson teaching foundational data and coding skills to researchers worldwide<% /desc %>",

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,10 @@
+# a sitemap can be generated for urls
+
+    Code
+      urls_to_sitemap(urls)
+    Output
+      {xml_document}
+      <urlset xml2ns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      [1] <url>\n  <loc>https://example.com/one</loc>\n</url>
+      [2] <url>\n  <loc>https://example.com/two</loc>\n</url>
+

--- a/tests/testthat/test-build_episode.R
+++ b/tests/testthat/test-build_episode.R
@@ -26,6 +26,15 @@ test_that("build_episode_md() works independently", {
 
 })
 
+
+test_that("build_episode_html() returns nothing for an empty page", {
+  tmp <- fs::path(res, "DELETEME")
+  withr::local_file(tmp)
+  writeLines("---\nlayout: what\n---\n\n", tmp)
+  expect_null(build_episode_html(tmp, quiet = TRUE))
+})
+
+
 test_that("build_episode_html() works independently", {
 
 

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -1,5 +1,6 @@
 
 tmp <- res <- restore_fixture()
+metadata_json <- trimws(create_metadata_jsonld(tmp))
 sitepath <- fs::path(tmp, "site", "docs")
 
 
@@ -16,18 +17,21 @@ test_that("Lessons built for the first time are noisy", {
 })
 
 
+test_that("Metadata is recorded as the correct type", {
+  expect_match(metadata_json, "\"@type\": \"TrainingMaterial\"", fixed = TRUE)
+})
+
 test_that("Lesson websites contains metadata", {
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   skip_on_os("windows")
 
-  json <- trimws(create_metadata_jsonld(tmp))
   idx <- xml2::read_html(fs::path(path_site(tmp), "docs", "index.html"))
 
   actual <- xml2::xml_find_first(idx, ".//script[@type='application/ld+json']")
   actual <- trimws(xml2::xml_text(actual))
 
-  expect_identical(actual, json)
+  expect_identical(actual, metadata_json)
 
 })
 

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -16,6 +16,12 @@ test_that("Lessons built for the first time are noisy", {
 
 })
 
+test_that("sitemap exists", {
+  sitemap <- fs::path(sitepath, "sitemap.xml")
+  expect_true(fs::file_exists(sitemap))
+  expect_equal(xml2::xml_name(xml2::read_xml(sitemap)), "urlset")
+})
+
 
 test_that("Metadata is recorded as the correct type", {
   expect_match(metadata_json, "\"@type\": \"TrainingMaterial\"", fixed = TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -16,3 +16,8 @@ test_that("copy assets will fail gracefully", {
     "There was an issue copying")
 
 })
+
+test_that("a sitemap can be generated for urls", {
+  urls <- c("https://example.com/one", "https://example.com/two")
+  expect_snapshot(urls_to_sitemap(urls))
+})


### PR DESCRIPTION
This will update the metadata to be TrainingMaterial instead of LearningResource to fix #236 and bumps pegboard to version 0.1.0 to address https://github.com/carpentries/pegboard/pull/76

This PR will also fix #243 and fix #237 