### PR TITLE
avoid infinite loops with serve()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,16 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
            role = c("aut", "cre"),
-           email = "zkamvar@gmail.com",
+           email = "zkamvar@carpentries.org",
            comment = c(ORCID = "0000-0003-1458-7108")),
     person(given = "François",
            family = "Michonneau",
            role = c("ctb"),
-           email = "fmichonneau@carpentries.org"),
+           email = "francois@carpentries.org"),
     person())
 Description: We provide tools to build a Carpentries-themed lesson repository
   into an accessible standalone static website. These include local tools and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.1.4
+
+BUG FIX
+-------
+
+* `sandpaper::build_lesson()` no longer creates an infinite loop when called
+  after `sandpaper::serve()` (@zkamvar, #246)
+
 # sandpaper 0.1.3
 
 MISC

--- a/R/serve.R
+++ b/R/serve.R
@@ -21,6 +21,8 @@
 #'  sandpaper::serve()
 #' }
 #nocov start
+# Note: we can not test this in covr because I'm not entirely sure of how to get
+#       it going
 serve <- function(path = ".") {
   path <- root_path(path)
   rend <- function(file_list = ".") {
@@ -28,7 +30,23 @@ serve <- function(path = ".") {
       build_lesson(f, preview = FALSE)
     }
   }
+  # path to the production folder that {servr} needs to render
+  prod <- fs::path(path_site(path), "docs") 
+  # filter function generator for {servr} to exclude the site folder
+  #
+  # This assumes that the input to the function will be whole file names
+  # which is the output of list.files() with recurse = TRUE and
+  # full.names = TRUE
+  #
+  # @param base the base path
+  make_filter <- function(base = path) {
+    no_site <- file.path(base, "site")
+    no_git  <- file.paths(base, ".git")
+    # return a filter function for the files
+    function(x) x[!startsWith(x, no_site) | !startsWith(x, no_git)]
+  }
+  # to start, build the site and then watch things:
   rend()
-  servr::httw(fs::path(path_site(path), "docs"), watch = path, handler = rend)
+  servr::httw(prod, watch = path, filter = make_filter(path), handler = rend)
 }
 #nocov end


### PR DESCRIPTION
If a user calls build_lesson() after they call serve(), it should not create an infinite loop of building. This will fix #246