### PR TITLE
don't use newlines in set_config()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.1.6
+
+BUG FIX
+-------
+
+* `set_dropdown()` no longer fails with {cli} version 3.2.0
+
 # sandpaper 0.1.5
 
 INTERNAL

--- a/R/set_dropdown.R
+++ b/R/set_dropdown.R
@@ -96,9 +96,9 @@ set_config <- function(pairs = NULL, path = ".", write = FALSE) {
       cli::cli_text(c(cli::col_yellow("+ "), line[i]))
     }
     the_call[["write"]] <- TRUE
-    cll <- paste(utils::capture.output(the_call), collapse = "\n")
+    cll <- gsub("\\s+", " ", paste(utils::capture.output(the_call), collapse = ""))
     cli::cli_alert_info("To save this configuration, use\n\n{.code {cll}}")
-    return(the_call)
+    return(invisible(the_call))
   }
 }
 

--- a/tests/testthat/_snaps/set_dropdown.md
+++ b/tests/testthat/_snaps/set_dropdown.md
@@ -9,11 +9,7 @@
       + license: 'CC0'
       i To save this configuration, use
       
-      `set_config(pairs = list(title = "test: title", license = "CC0"), 
-          path = tmp, write = TRUE)`
-    Output
-      set_config(pairs = list(title = "test: title", license = "CC0"), 
-          path = tmp, write = TRUE)
+      `set_config(pairs = list(title = "test: title", license = "CC0"), path = tmp, write = TRUE)`
 
 # set_config() will write items [plain]
 


### PR DESCRIPTION
This replaces newlines with blank lines in the user displayed info for
`set_config()` to work around https://github.com/r-lib/cli/issues/417

this will fix #252
