### PR TITLE
fix bug with links and footnotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.3.1
+
+BUG FIXES
+---------
+
+* Documents with footnotes without trailing newlines will now parse the external
+  links correctly by adding a newline between the document and the links.
+
 # sandpaper 0.3.0
 
 NEW FEATURES

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -49,6 +49,7 @@ render_html <- function(path_in, ..., quiet = FALSE) {
     # if we have links, we concatenate our input files 
     tmpin <- tempfile(fileext = ".md")
     fs::file_copy(path_in, tmpin)
+    cat("\n", file = tmpin, append = TRUE)
     file.append(tmpin, links)
     path_in <- tmpin
     on.exit(unlink(tmpin), add = TRUE)

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -5,10 +5,10 @@ test_that("sandpaper.links can be included", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- withr::local_tempfile()
   tnk <- withr::local_tempfile()
-  writeLines("This has a [link at the end] in a separate file", tmp)
+  writeLines("This has a [link at the end] in a separate file[^1]\n\n[^1]: :)", tmp)
   writeLines("[link at the end]: https://example.com/link", tnk)
   withr::local_options(list("sandpaper.links" = tnk))
-  expect_match(render_html(tmp), "example.com/link")
+  expect_no_match(render_html(tmp), "\\[link at the end\\]")
 })
 
 


### PR DESCRIPTION
This will fix the situation where a footnote at the end of a document with no newline accidentally collects links because of the concatenation procedure to include links before rendering to HTML.


