### PR TITLE
Fix local linking issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     withr,
     jsonlite,
     sessioninfo,
-    varnish (>= 0.1.0)
+    varnish (>= 0.1.5)
 Additional_repositories: https://carpentries.r-universe.dev/
 Remotes:
   ropensci/tinkr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,23 @@
 BUG FIXES
 ---------
 
- * Links from the index page to the setup or any episodes now correctly render.
+ * Links from the index page to the setup or any episodes now correctly render
+ * Links to the setup page now redirect to `index.html#setup` (@zkamvar, #262)
+ * The setup page is now included in the instructor view after the schedule
+ * The setup in the index page is now a separate section with the id "setup"
+ * The schedule in the instructor index page is now in a separate section with 
+   the id "schedule"
+
+DEPENDENCIES
+------------
+
+ * The minimum version of {varnish} required is now 0.1.5
+
+CONTINUOUS INTEGRATION
+----------------------
+
+ * A small bug in the update cache workflow that caused a silent error with no
+   detremental effect was fixed (@zkamvar, #250)
 
 # sandpaper 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.3.3
+
+BUG FIXES
+---------
+
+ * Links from the index page to the setup or any episodes now correctly render.
+
 # sandpaper 0.3.2
 
 DEPENDENCIES

--- a/R/build_home.R
+++ b/R/build_home.R
@@ -29,6 +29,7 @@ build_home <- function(pkg, quiet, sidebar = NULL, new_setup = TRUE, next_page =
   page_globals$instructor$update(nav)
   page_globals$instructor$set("syllabus", paste(syl, collapse = ""))
   page_globals$instructor$set("readme", use_instructor(html))
+  page_globals$instructor$set("setup", use_instructor(setup))
 
   nav$pagetitle <- "Summary and Setup"
   nav$page_forward <- as_html(nav$page_forward)

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -4,6 +4,7 @@ fix_nodes <- function(nodes = NULL) {
   fix_callouts(nodes)
   fix_codeblocks(nodes)
   fix_figures(nodes)
+  fix_setup_link(nodes)
 }
 
 fix_headings <- function(nodes = NULL) {
@@ -68,6 +69,17 @@ fix_callouts <- function(nodes = NULL) {
   xml2::xml_set_attr(h3, "class", "callout-title")
   inner_div <- xml2::xml_parent(h3)
   xml2::xml_set_attr(inner_div, "class", "callout-inner")
+  invisible(nodes)
+}
+
+fix_setup_link <- function(nodes = NULL) {
+  if (length(nodes) == 0) return(nodes)
+  links <- xml2::xml_find_all(nodes, ".//a")
+  hrefs <- xml2::url_parse(xml2::xml_attr(links, "href"))
+  setup_links <- hrefs$scheme == "" & 
+    hrefs$server == "" &
+    hrefs$path == "setup.html"
+  xml2::xml_set_attr(links[setup_links], "href", "index.html#setup")
   invisible(nodes)
 }
 

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -406,7 +406,6 @@ end
 --   return s
 -- end
 flatten_links = function(el)
-  local pat = "^%.%./"
   local tgt;
   if el.target == nil then
     tgt = el.src
@@ -414,11 +413,12 @@ flatten_links = function(el)
     tgt = el.target
   end
   -- Flatten local redirects, e.ge. ../episodes/link.md goes to link.md
-  tgt,_ = tgt:gsub(pat.."episodes/", "")
-  tgt,_ = tgt:gsub(pat.."learners/", "")
-  tgt,_ = tgt:gsub(pat.."instructors/", "")
-  tgt,_ = tgt:gsub(pat.."profiles/", "")
+  local pat = "^%.%./"
   tgt,_ = tgt:gsub(pat, "")
+  tgt,_ = tgt:gsub("^episodes/", "")
+  tgt,_ = tgt:gsub("^learners/", "")
+  tgt,_ = tgt:gsub("^instructors/", "")
+  tgt,_ = tgt:gsub("^profiles/", "")
   -- rename local markdown/Rmarkdown
   -- link.md goes to link.html
   -- link.md#section1 goes to link.html#section1

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -23,7 +23,9 @@ jobs:
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "::set-output name=ok::true"
             echo "Running on request"
-          elif [[ `date +%d` -le 7 ]]; then
+          # using single brackets here to avoid 08 being interpreted as octal
+          # https://github.com/carpentries/sandpaper/issues/250
+          elif [ `date +%d` -le 7 ]; then
             # If the Tuesday lands in the first week of the month, run it
             echo "::set-output name=ok::true"
             echo "Running on schedule"

--- a/tests/testthat/examples/ex.md
+++ b/tests/testthat/examples/ex.md
@@ -17,7 +17,7 @@ exercises: 9
 
 # Markdown
 
-::: challenge
+::: {.challenge time=10}
 
 How do you write markdown divs?
 
@@ -27,7 +27,7 @@ This [rmd link also](../episodes/01-Introduction.Rmd)
 
 This [rmd is safe](https://example.com/01-Introduction.Rmd)
 
-This [too](../learners/Setup.md#windows-setup 'windows setup')
+This [too](learners/Setup.md#windows-setup 'windows setup')
 
 ![link should be transformed](../episodes/fig/Setup.png){alt='alt text'}
 

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -30,8 +30,13 @@ test_that("[build_home()] works independently", {
   )
   learn_index <- fs::path(pkg$dst_path, "index.html")
   expect_true(fs::file_exists(learn_index))
+  idx <- xml2::read_html(learn_index)
+  expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='setup'])"))
   instruct_index <- fs::path(pkg$dst_path, "instructor", "index.html")
   expect_true(fs::file_exists(instruct_index))
+  idx <- xml2::read_html(instruct_index)
+  expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='setup'])"))
+  expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='schedule'])"))
 })
 
 test_that("[build_home()] learner index file is index and setup", {

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -1,6 +1,7 @@
 
 test_that("empty args result in nothing happening", {
   expect_null(fix_nodes())
+  expect_null(fix_setup_link())
   expect_null(fix_headings())
   expect_null(fix_codeblocks())
   expect_null(add_code_heading())
@@ -12,6 +13,7 @@ test_that("empty args result in nothing happening", {
 
 test_that("NULL args result in nothing happening", {
   expect_null(fix_nodes(NULL))
+  expect_null(fix_setup_link(NULL))
   expect_null(fix_headings(NULL))
   expect_null(fix_codeblocks(NULL))
   expect_null(add_code_heading(NULL))
@@ -23,6 +25,7 @@ test_that("NULL args result in nothing happening", {
 
 test_that("empty character entries result in nothing happening", {
   expect_length(fix_nodes(character(0)), 0)
+  expect_length(fix_setup_link(character(0)), 0)
   expect_length(fix_headings(character(0)), 0)
   expect_length(fix_codeblocks(character(0)), 0)
   expect_length(add_code_heading(character(0)), 0)


### PR DESCRIPTION
This fixes a few issues with local links in some situations:

1. links originating from a page in the root of the repository now are treated
   the same way as links from within a folder in the repository (e.g. 
   a link that is `[first episode](episodes/introduction.md)` will now properly 
   link to the episode in the rendered HTML.
2. links to the setup page will now properly render to the correct place (index)
3. The setup will contain a section (eventually to be replaced by a
   callout with nav elements).

This also addresses #250 where the BASH was interpreting 08 as octal and freaking out.

This will fix #262 and #250 