### PR TITLE
change keypoints.html to key-points.html

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.3.4
+Version: 0.3.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.3.5
+
+BUG FIX
+-------
+
+* `keypoints.html` is now rendered as `key-points.html` to fix navigation error
+  with varnish.
+
 # sandpaper 0.3.4
 
 CONTINUOUS INTEGRATION

--- a/R/build_keypoints.R
+++ b/R/build_keypoints.R
@@ -21,7 +21,7 @@ build_keypoints <- function(pkg, quiet, sidebar = NULL) {
   fix_nodes(html)
 
   this_dat <- list(
-    this_page = "keypoints.html",
+    this_page = "key-points.html",
     body = use_learner(html),
     pagetitle = "Keypoints"
   )
@@ -31,5 +31,5 @@ build_keypoints <- function(pkg, quiet, sidebar = NULL) {
   page_globals$meta$update(this_dat)
 
   build_html(template = "extra", pkg = pkg, nodes = html,
-    global_data = page_globals, path_md = "keypoints.html", quiet = quiet)
+    global_data = page_globals, path_md = "key-points.html", quiet = quiet)
 }

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -152,7 +152,7 @@ test_that("[build_keypoints()] works independently", {
 test_that("[build_keypoints()] learner and instructor views are identical", {
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
-  instruct <- fs::path(pkg$dst_path, "instructor", "keypoints.html")
+  instruct <- fs::path(pkg$dst_path, "instructor", "key-points.html")
   instruct <- xml2::read_html(instruct)
 
   # Instructor sidebar is formatted properly
@@ -160,17 +160,17 @@ test_that("[build_keypoints()] learner and instructor views are identical", {
   expect_length(sidebar, 1L)
   sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
   expect_length(sidelinks, 4L)
-  expect_match(sidelinks[[1]], "href=[\"]..[/]keypoints.html")
+  expect_match(sidelinks[[1]], "href=[\"]..[/]key-points.html")
   expect_match(sidelinks[[2]], "Summary and Schedule")
 
-  learn <- fs::path(pkg$dst_path, "keypoints.html")
+  learn <- fs::path(pkg$dst_path, "key-points.html")
   learn <- xml2::read_html(learn)
   
   # Learner sidebar is formatted properly
   sidebar <- xml2::xml_find_all(learn, ".//div[@class='sidebar']")
   expect_length(sidebar, 1L)
   sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
-  expect_match(sidelinks[[1]], "href=[\"]instructor[/]keypoints.html")
+  expect_match(sidelinks[[1]], "href=[\"]instructor[/]key-points.html")
   expect_match(sidelinks[[2]], "Summary and Setup")
 
   # sections are equal
@@ -181,11 +181,11 @@ test_that("[build_keypoints()] learner and instructor views are identical", {
   # the instructor metadata contains this page information
   meta <- xml2::xml_find_first(instruct, ".//script[@type='application/ld+json']")
   meta <- trimws(xml2::xml_text(meta))
-  expect_match(meta, "lesson-example/instructor/keypoints.html")
+  expect_match(meta, "lesson-example/instructor/key-points.html")
 
   # the learner metadata contains this page information
   meta <- xml2::xml_find_first(learn, ".//script[@type='application/ld+json']")
   meta <- trimws(xml2::xml_text(meta))
-  expect_match(meta, "lesson-example/keypoints.html")
+  expect_match(meta, "lesson-example/key-points.html")
 })
 

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -140,11 +140,11 @@ test_that("[build_profiles()] learner and instructor views are identical", {
 test_that("[build_keypoints()] works independently", {
 
   skip_if_not(rmarkdown::pandoc_available("2.11"))
-  expect_false(fs::file_exists(fs::path(pkg$dst_path, "keypoints.html")))
-  expect_false(fs::file_exists(fs::path(pkg$dst_path, "instructor", "keypoints.html")))
+  expect_false(fs::file_exists(fs::path(pkg$dst_path, "key-points.html")))
+  expect_false(fs::file_exists(fs::path(pkg$dst_path, "instructor", "key-points.html")))
   build_keypoints(pkg, quiet = TRUE)
-  expect_true(fs::file_exists(fs::path(pkg$dst_path, "keypoints.html")))
-  expect_true(fs::file_exists(fs::path(pkg$dst_path, "instructor", "keypoints.html")))
+  expect_true(fs::file_exists(fs::path(pkg$dst_path, "key-points.html")))
+  expect_true(fs::file_exists(fs::path(pkg$dst_path, "instructor", "key-points.html")))
 
 })
 


### PR DESCRIPTION
this changes all sandpaper sites to produce key-points.html instead of keypoints.html to align with varnish. That being said, it could change in the future.
