### PR TITLE
Update workflows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@ NEW SUGGESTS
 * {mockr} is now a suggested package (aka soft-dependency) to facilitate testing
   functions that do not need an entire lesson set up to test their functionality
 
+CONTINUOUS INTEGRATION
+----------------------
+
+ * `setup-r` and `setup-pandoc` actions have been pinned to version 2
+ * `setup-r` action now uses the default R installation on GitHub's runner,
+   which decreases build times by ~ 1 minute.
+ * All R actions will use the RStudio Package Manager, which should avoid overly
+   lengthy build times. 
 
 # sandpaper 0.5.0
 

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -41,10 +41,13 @@ jobs:
           path: ${{ env.MD }}
 
       - name: "Set up R"
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          install-r: false
 
       - name: "Set up Pandoc"
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: "2.11.4"
 

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -30,12 +30,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Set up R"
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          install-r: false
 
       - name: "Set up Pandoc"
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: "2.11.4"
 

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -21,6 +21,10 @@ jobs:
   full-build:
     name: "Build Full Site"
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: write
+      pages: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/.local/share/renv/

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -96,7 +96,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Set up R"
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          install-r: false
 
       - name: "Update {renv} deps and determine if a PR is needed"
         id: update


### PR DESCRIPTION
 - setup-r and setup-pandoc are now both v2
 - setup-r now uses the R version that comes with GitHub Actions. This
   should cut the build time by ~ 1 minute
 - all actions that use R use the RSPM by default, which will also
   improve build times.
 - explicitly sets permissions for the deployment action (this will fix #280)