### PR TITLE
use `globalenv()` for `build_episode_md()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.5.3
+Version: 0.5.4
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.5.4
+
+BUG FIX
+-------
+
+* `build_episode_md()` argument `workenv` now defaults to `globalenv()` to avoid
+  S3 dispatch issues that can occur in `new.env()` (see https://github.com/carpentries/sandpaper/issues/288)
+
 # sandpaper 0.5.3
 
 BUG FIX

--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -178,7 +178,8 @@ get_nav_data <- function(path_md, path_src = NULL, home = NULL,
 #'   is effectively useless.
 #' @param outdir the directory to write to
 #' @param workdir the directory where the episode should be rendered
-#' @param env a blank environment
+#' @param workenv an environment to use for evaluation. Defaults to the global
+#'   environment, which evaluates to the environment from [callr::r()]. 
 #' @param quiet if `TRUE`, output is suppressed, default is `FALSE` to show 
 #'   {knitr} output.
 #' @return the path to the output, invisibly
@@ -209,7 +210,7 @@ get_nav_data <- function(path_md, path_src = NULL, home = NULL,
 #' res <- build_episode_md(fun_file, outdir = fun_dir, workdir = fun_dir)
 build_episode_md <- function(path, hash = NULL, outdir = path_built(path), 
                              workdir = path_built(path), 
-                             workenv = new.env(), profile = "lesson-requirements", quiet = FALSE) {
+                             workenv = globalenv(), profile = "lesson-requirements", quiet = FALSE) {
 
   # define the output
   md <- fs::path_ext_set(fs::path_file(path), "md")

--- a/man/build_episode_md.Rd
+++ b/man/build_episode_md.Rd
@@ -9,7 +9,7 @@ build_episode_md(
   hash = NULL,
   outdir = path_built(path),
   workdir = path_built(path),
-  workenv = new.env(),
+  workenv = globalenv(),
   profile = "lesson-requirements",
   quiet = FALSE
 )
@@ -24,10 +24,11 @@ is effectively useless.}
 
 \item{workdir}{the directory where the episode should be rendered}
 
+\item{workenv}{an environment to use for evaluation. Defaults to the global
+environment, which evaluates to the environment from \code{\link[callr:r]{callr::r()}}.}
+
 \item{quiet}{if \code{TRUE}, output is suppressed, default is \code{FALSE} to show
 {knitr} output.}
-
-\item{env}{a blank environment}
 }
 \value{
 the path to the output, invisibly

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -13,7 +13,7 @@ We provide tools to build a Carpentries-themed lesson repository into an accessi
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/carpentries/sandpaper/}
+  \item \url{https://carpentries.github.io/sandpaper/}
   \item Report bugs at \url{https://github.com/carpentries/sandpaper/issues/}
 }
 

--- a/tests/testthat/examples/s3.Rmd
+++ b/tests/testthat/examples/s3.Rmd
@@ -1,0 +1,29 @@
+---
+title: Fun times
+---
+
+
+# new page
+
+This is coming from `r R.version.string` with an [internal link](fun.Rmd)
+
+::: instructor
+this is an instructor note
+:::
+
+```{r}
+#| name: example
+point <- function(x, y) {
+  stopifnot(is.numeric(x), is.numeric(y))
+  structure(list(x = x, y = y), class = "point")
+}
+
+abs.point <- function(x) {
+  sqrt(x$x ^ 2 + x$y ^ 2)
+}
+
+points <- mapply(point, runif(5), runif(5), SIMPLIFY = FALSE)
+
+sapply(points, abs)
+```
+

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -25,7 +25,12 @@ test_that("Lessons built for the first time are noisy", {
 
 })
 
-htmls <- read_all_html(sitepath)
+
+htmls <- NULL
+if (rmarkdown::pandoc_available("2.11")) {
+  htmls <- read_all_html(sitepath)
+}
+
 pkg <- pkgdown::as_pkgdown(fs::path_dir(sitepath))
 
 test_that("build_lesson() also builds the extra pages", {


### PR DESCRIPTION
When `knitr::knit()` is being called from `callr::r()`, it does not need
a `new.env()` to avoid manipulating the user's workspace. In fact, when
`new.env()` is used, it creates a situation in which S3 dispatch is not
working.

This will fix #288

I have also added a control structure that will fix #282 