### PR TITLE
update workflows; bump version; bump news

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.5.6
+Version: 0.5.7
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.5.7
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* Workflows that update lesson elements will now report a more obvious summary
+  of next steps to take with an invalid token (see https://github.com/carpentries/actions/pull/45)
+
 # sandpaper 0.5.6
 
 CONTINUOUS INTEGRATION

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -65,23 +65,6 @@ jobs:
         with:
           token: ${{ secrets.SANDPAPER_WORKFLOW }}
 
-  bad_token:
-    name: "Invalid/Missing Token"
-    runs-on: ubuntu-latest
-    needs: check_token
-    if: ${{ needs.check_token.outputs.workflow != 'true' }}
-    steps:
-      - name: "Instructions to create a new token"
-        run: |
-          printf "::warning::The SANDPAPER_WORKFLOW secret is missing, invalid, "\
-          "or does not have the right scope to update the package cache.\n"\
-          "If you want to have automated pull request updates to your package cache, "\
-          "you will need to generate a new token by visiting "\
-          "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%%20Token%%20%%28${{ github.repository }}%%29\n"\
-          "Once you have created the token, copy it to your clipboard and go to "\
-          "https://github.com/${{ github.repository }}/settings/secrets/actions/new "\
-          "and enter SANDPAPER_WORKFLOW for the 'Name' and paste your key for the 'Value'."
-
   update_cache:
     name: "Update Package Cache"
     needs: check_token

--- a/inst/workflows/update-workflows.yaml
+++ b/inst/workflows/update-workflows.yaml
@@ -29,21 +29,6 @@ jobs:
         with:
           token: ${{ secrets.SANDPAPER_WORKFLOW }}
 
-  bad_token:
-    name: "Invalid/Missing Token"
-    runs-on: ubuntu-latest
-    needs: check_token
-    if: ${{ needs.check_token.outputs.workflow != 'true' }}
-    steps:
-      - name: "Instructions to create a new token"
-        run: |
-          printf "::warning::The SANDPAPER_WORKFLOW token workflow scope is not valid\n"\
-          "If you want to have periodic pull request updates, you will need to generate a new token by going to "\
-          "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%%20Token%%20%%28${{ github.repository }}%%29\n"\
-          "Once you have created the token, copy it to your clipboard and go to "\
-          "https://github.com/${{ github.repository }}/settings/secrets/actions/new "\
-          "and enter SANDPAPER_WORKFLOW for the 'Name' and paste your key for the 'Value'."
-
   update_workflow:
     name: "Update Workflow"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This updates the "update-" workflows to have better reporting by relying on the update from https://github.com/carpentries/actions/pull/45 and removing the embedded warning.