### PR TITLE
update main workflow: add checkbox to manual run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.5.7
+Version: 0.5.8
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# sandpaper 0.5.8
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* Running the main workflow from GitHub's actions tab now uses a checkbox to
+  indicate if the markdown file cache should be cleared.
+* The README file for the workflows no longer contains a link to an image that
+  does not exist.
+
 # sandpaper 0.5.7
 
 CONTINUOUS INTEGRATION

--- a/inst/workflows/README.md
+++ b/inst/workflows/README.md
@@ -117,7 +117,7 @@ pull requests that do not pass checks and do not have bots commented on them.**
 This series of workflows all go together and are described in the following 
 diagram and the below sections:
 
-![Graph representation of a pull request](../../vignettes/articles/img/pr-flow.dot.svg)
+![Graph representation of a pull request](https://carpentries.github.io/sandpaper/articles/img/pr-flow.dot.svg)
 
 ### Recieve Pull Request (pr-recieve.yaml)
 

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -14,9 +14,10 @@ on:
         required: true
         default: 'Maintainer (via GitHub)'
       reset:
-        description: 'Should the cached markdown files be reset? (true/false)'
-        required: true
+        description: 'Reset cached markdown files'
+        required: false
         default: false
+        type: boolean
 jobs:
   full-build:
     name: "Build Full Site"


### PR DESCRIPTION
This PR finally fixes a thing that has been bothering me about the manual dispatch of the sandpaper main workflow: a boolean option. Now, to clear the cache, you can use a checkbox instead of having to type "true" or "false" 🎉 
