### PR TITLE
Adjust default config

### DIFF
--- a/R/create_lesson.R
+++ b/R/create_lesson.R
@@ -52,7 +52,7 @@ create_lesson <- function(path, name = fs::path_file(path), rmd = TRUE, rstudio 
   copy_template("config", path, "config.yaml",
     values = list(
       title      = if (is.null(match.call()$name)) "Lesson Title" else siQuote(name),
-      carpentry  = "cp",
+      carpentry  = "incubator",
       life_cycle = "pre-alpha",
       license    = "CC-BY 4.0",
       source     = glue::glue("https://github.com/{account}/{basename(path)}"),
@@ -97,11 +97,10 @@ create_lesson <- function(path, name = fs::path_file(path), rmd = TRUE, rstudio 
     if (usethis::proj_activate(path)) {
       on.exit()
     }
-  } 
+  }
 
 
   cli::cli_status_clear()
   invisible(return(path))
 
 }
-

--- a/inst/templates/config-template.txt
+++ b/inst/templates/config-template.txt
@@ -6,7 +6,8 @@
 # swc: Software Carpentry
 # dc: Data Carpentry
 # lc: Library Carpentry
-# cp: Carpentries (to use for instructor traning for instance)
+# cp: Carpentries (to use for instructor training for instance)
+# incubator: The Carpentries Incubator
 carpentry: {{ carpentry }}
 
 # Overall title for pages.
@@ -35,20 +36,20 @@ branch: {{ branch }}{{ ^branch }}main{{ /branch }}
 contact: {{ contact }}
 
 # Navigation ------------------------------------------------
-# 
+#
 # Use the following menu items to specify the order of
 # individual pages in each dropdown section. Leave blank to
 # include all pages in the folder.
 #
 # Example -------------
-# 
+#
 # episodes:
 # - introduction.md
 # - first-steps.md
-# 
+#
 # learners:
 # - setup.md
-# 
+#
 # instructors:
 # - instructor-notes.md
 #
@@ -56,7 +57,7 @@ contact: {{ contact }}
 # - one-learner.md
 # - another-learner.md
 
-# Order of episodes in your lesson 
+# Order of episodes in your lesson
 episodes: {{ episodes }}
 
 # Information for Learners
@@ -74,4 +75,3 @@ profiles: {{ profiles }}
 # sandpaper and varnish versions) should live
 
 {{{ custom_items }}}
-

--- a/inst/templates/config-template.txt
+++ b/inst/templates/config-template.txt
@@ -13,7 +13,7 @@ carpentry: {{ carpentry }}
 # Overall title for pages.
 title: {{ title }}
 
-# Date the lesson was created (this is empty by default)
+# Date the lesson was created (YYYY-MM-DD, this is empty by default)
 created: ~
 
 # Comma-separated list of keywords for the lesson


### PR DESCRIPTION
- document "incubator" option for "carpentry" field in the default `config.yaml`, make this the default value for that field.
- fix a minor typo
- add a hint about the required format of the"created" date string 