### PR TITLE
fix mobile nav and quickfix for downlit update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -55,7 +55,7 @@ Suggests:
     withr,
     jsonlite,
     sessioninfo,
-    varnish (>= 0.1.5),
+    varnish (>= 0.2.1),
     mockr
 Additional_repositories: https://carpentries.r-universe.dev/
 Remotes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ BUG FIX
 * The sidebar navigation in mobile and tablet views now includes all the 
   information that was included in the navigation bar for the desktop mode. 
   (reported: https://github.com/carpentries/workbench/issues/16#issuecomment-1165307355 by @Athanasiamo and #306, fixed: #309 by @zkamvar)
+* the downit shims have been updated to be resiliant to upstream changes
+
 
 # sandpaper 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ BUG FIX
 
 * The sidebar navigation in mobile and tablet views now includes all the 
   information that was included in the navigation bar for the desktop mode. 
-  (reported: https://github.com/carpentries/workbench/issues/16#issuecomment-1165307355 by @Athanasiamo and #306, fixed: #307 by @zkamvar)
+  (reported: https://github.com/carpentries/workbench/issues/16#issuecomment-1165307355 by @Athanasiamo and #306, fixed: #309 by @zkamvar)
 
 # sandpaper 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.6.2
+
+BUG FIX
+-------
+
+* The sidebar navigation in mobile and tablet views now includes all the 
+  information that was included in the navigation bar for the desktop mode. 
+  (reported: https://github.com/carpentries/workbench/issues/16#issuecomment-1165307355 by @Athanasiamo and #306, fixed: #307 by @zkamvar)
+
 # sandpaper 0.6.1
 
 MISC

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -61,8 +61,7 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
   sidebar <- create_sidebar(c(fs::path(built_path, "index.md"), chapters))
   # shim for downlit ----------------------------------------------------------
   shimstem_file <- system.file("pkgdown", "shim.R", package = "sandpaper")
-  # expected <- "5484c37e9b9c324361d775a10dea4946"
-  expected <- "8808c462f326fea560ed2d748ad459e5"
+  expected <- "41aea9a01589d636768f56a333343ec5"
   actual   <- tools::md5sum(shimstem_file)
   if (expected == actual) {
     # evaluate the shim in our namespace

--- a/R/utils-sidebar.R
+++ b/R/utils-sidebar.R
@@ -46,9 +46,8 @@ create_resources_dropdown <- function(files, type = "learners") {
       info <- get_navbar_info(f)
       make_links(info$href, parse_title(info$text))
     }, character(2))
-    prof <- make_links("profiles.html", "Learner Profiles")
-    out[["extras"]] <- unname(c(prof[1], res[1, , drop = TRUE]))
-    out[["resources"]] <- unname(c(prof[2], res[2, , drop = TRUE]))
+    out[["extras"]] <- unname(res[1, , drop = TRUE])
+    out[["resources"]] <- unname(res[2, , drop = TRUE])
   }
   return(out)
 }

--- a/inst/pkgdown/shim.R
+++ b/inst/pkgdown/shim.R
@@ -16,7 +16,7 @@ tr <- dl$token_href
 ht <- dl$href_topic
 unlockBinding("token_href", dl)
 unlockBinding("href_topic", dl)
-dl$token_href <- function(token, text) rep(NA, length(token))
-dl$href_topic <- function(topic, package) NA_character_
+dl$token_href <- function(token, ...) rep(NA, length(token))
+dl$href_topic <- function(...) NA_character_
 parse(text = "{\ndl$token_href <- tr\nlockBinding('token_href', dl)\n}")
 parse(text = "{\ndl$href_topic <- ht\nlockBinding('href_topic', dl)\n}")

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -14,6 +14,8 @@ We provide tools to build a Carpentries-themed lesson repository into an accessi
 Useful links:
 \itemize{
   \item \url{https://carpentries.github.io/sandpaper/}
+  \item \url{https://github.com/carpentries/sandpaper/}
+  \item \url{https://carpentries.github.io/workbench/}
   \item Report bugs at \url{https://github.com/carpentries/sandpaper/issues/}
 }
 
@@ -24,6 +26,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item François Michonneau \email{francois@carpentries.org} [contributor]
+  \item Toby Hodges \email{tobyhodges@carpentries.org} [contributor]
 }
 
 }

--- a/tests/testthat/_snaps/build_html.md
+++ b/tests/testthat/_snaps/build_html.md
@@ -1,0 +1,58 @@
+# [build_home()] learner index file is index and setup
+
+    Code
+      writeLines(as.character(items))
+    Output
+      <li><a href="#data-sets">Data Sets</a></li>
+      <li><a href="#software-setup">Software Setup</a></li>
+      <li>
+                              <a href="key-points.html">Key Points</a>
+                            </li>
+      <li>
+                              <a href="reference.html#glossary">Glossary</a>
+                            </li>
+      <li>
+                              <a href="profiles.html">Learner Profiles</a>
+                            </li>
+
+# [build_home()] instructor index file is index and schedule
+
+    Code
+      writeLines(as.character(items))
+    Output
+      <li>
+                              <a href="../instructor/key-points.html">Key Points</a>
+                            </li>
+      <li>
+                              <a href="../instructor/instructor-notes.html">Instructor Notes</a>
+                            </li>
+      <li>
+                              <a href="../instructor/images.html">Extract All Images</a>
+                            </li>
+
+# [build_profiles()] learner and instructor views are identical
+
+    Code
+      writeLines(sidelinks_instructor)
+    Output
+      <a href="../profiles.html">Learner View</a>
+      <a href="index.html">Summary and Schedule</a>
+      <a href="01-introduction.html">1. introduction</a>
+      <a href="../instructor/key-points.html">Key Points</a>
+      <a href="../instructor/instructor-notes.html">Instructor Notes</a>
+      <a href="../instructor/images.html">Extract All Images</a>
+      <a href="../instructor/aio.html">See all in one page</a>
+
+---
+
+    Code
+      writeLines(sidelinks_learner)
+    Output
+      <a href="instructor/profiles.html">Instructor View</a>
+      <a href="index.html">Summary and Setup</a>
+      <a href="01-introduction.html">1. introduction</a>
+      <a href="key-points.html">Key Points</a>
+      <a href="reference.html#glossary">Glossary</a>
+      <a href="profiles.html">Learner Profiles</a>
+      <a href="aio.html">See all in one page</a>
+

--- a/tests/testthat/_snaps/build_lesson.md
+++ b/tests/testthat/_snaps/build_lesson.md
@@ -1,0 +1,28 @@
+# keypoints learner and instructor views are identical
+
+    Code
+      writeLines(sidelinks_instructor)
+    Output
+      <a href="../key-points.html">Learner View</a>
+      <a href="index.html">Summary and Schedule</a>
+      <a href="01-introduction.html">1. introduction</a>
+      <a href="02-second-episode.html">2. Second Episode!</a>
+      <a href="../instructor/key-points.html">Key Points</a>
+      <a href="../instructor/instructor-notes.html">Instructor Notes</a>
+      <a href="../instructor/images.html">Extract All Images</a>
+      <a href="../instructor/aio.html">See all in one page</a>
+
+---
+
+    Code
+      writeLines(sidelinks_learner)
+    Output
+      <a href="instructor/key-points.html">Instructor View</a>
+      <a href="index.html">Summary and Setup</a>
+      <a href="01-introduction.html">1. introduction</a>
+      <a href="02-second-episode.html">2. Second Episode!</a>
+      <a href="key-points.html">Key Points</a>
+      <a href="reference.html#glossary">Glossary</a>
+      <a href="profiles.html">Learner Profiles</a>
+      <a href="aio.html">See all in one page</a>
+

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -46,8 +46,7 @@ test_that("[build_home()] learner index file is index and setup", {
   html <- xml2::read_html(learn_index)
   # Dropdown contains ifnromation for the sections in the setup page
   items <- xml2::xml_find_all(html, ".//div[@class='accordion-body']/ul/li")
-  expect_length(items, 2L)
-  expect_equal(xml2::xml_text(items), c("Data Sets", "Software Setup"))
+  expect_snapshot(writeLines(as.character(items)))
 
   # There are four out links to the next page
   fwd <- xml2::xml_find_all(html, ".//a[starts-with(@class, 'chapter-link')]/@href")
@@ -69,8 +68,7 @@ test_that("[build_home()] instructor index file is index and schedule", {
 
   # there is only one dropdown in here and it is the common instructor linkouts
   items <- xml2::xml_find_all(html, ".//div[@class='accordion-body']/ul/li")
-  expect_length(items, 1L) 
-  expect_equal(xml2::xml_text(items), c("Learner Profiles"))
+  expect_snapshot(writeLines(as.character(items)))
 
   # There are four out links to the next page
   fwd <- xml2::xml_find_all(html, ".//a[starts-with(@class, 'chapter-link')]/@href")
@@ -107,9 +105,8 @@ test_that("[build_profiles()] learner and instructor views are identical", {
   sidebar <- xml2::xml_find_all(instruct, ".//div[@class='sidebar']")
   expect_length(sidebar, 1L)
   sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
-  expect_length(sidelinks, 5L)
-  expect_match(sidelinks[[1]], "href=[\"]..[/]profiles.html")
-  expect_match(sidelinks[[2]], "Summary and Schedule")
+  sidelinks_instructor <- as.character(xml2::xml_find_all(sidebar, ".//a"))
+  expect_snapshot(writeLines(sidelinks_instructor))
 
   learn <- fs::path(pkg$dst_path, "profiles.html")
   learn <- xml2::read_html(learn)
@@ -117,9 +114,8 @@ test_that("[build_profiles()] learner and instructor views are identical", {
   # Learner sidebar is formatted properly
   sidebar <- xml2::xml_find_all(learn, ".//div[@class='sidebar']")
   expect_length(sidebar, 1L)
-  sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
-  expect_match(sidelinks[[1]], "href=[\"]instructor[/]profiles.html")
-  expect_match(sidelinks[[2]], "Summary and Setup")
+  sidelinks_learner <- as.character(xml2::xml_find_all(sidebar, ".//a"))
+  expect_snapshot(writeLines(sidelinks_learner))
 
   # sections are equal
   learn_sections <- as.character(xml2::xml_find_all(learn, ".//section"))

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -164,7 +164,7 @@ test_that("Lesson websites contains instructor metadata", {
 
 test_that("single files can be built", {
 
-  create_episode("second-episode", path = tmp)
+  create_episode("Second Episode!", path = tmp)
   suppressMessages(s <- get_episodes(tmp))
   set_episodes(tmp, s, write = TRUE)
 
@@ -189,7 +189,7 @@ test_that("Individual files contain matching metadata", {
 
   actual <- xml2::xml_find_first(idx, ".//script[@type='application/ld+json']")
   actual <- trimws(xml2::xml_text(actual))
-  expect_match(actual, '"name": "second-episode"')
+  expect_match(actual, '"name": "Second Episode!"')
   expect_match(actual, "02-second-episode.html")
 })
 
@@ -281,24 +281,20 @@ test_that("keypoints learner and instructor views are identical", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   instruct <- fs::path(pkg$dst_path, "instructor", "key-points.html")
   instruct <- xml2::read_html(instruct)
+  learn <- fs::path(pkg$dst_path, "key-points.html")
+  learn <- xml2::read_html(learn)
 
   # Instructor sidebar is formatted properly
   sidebar <- xml2::xml_find_all(instruct, ".//div[@class='sidebar']")
   expect_length(sidebar, 1L)
-  sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
-  expect_length(sidelinks, 6L)
-  expect_match(sidelinks[[1]], "href=[\"]..[/]key-points.html")
-  expect_match(sidelinks[[2]], "Summary and Schedule")
+  sidelinks_instructor <- as.character(xml2::xml_find_all(sidebar, ".//a"))
+  expect_snapshot(writeLines(sidelinks_instructor))
 
-  learn <- fs::path(pkg$dst_path, "key-points.html")
-  learn <- xml2::read_html(learn)
-  
   # Learner sidebar is formatted properly
   sidebar <- xml2::xml_find_all(learn, ".//div[@class='sidebar']")
   expect_length(sidebar, 1L)
-  sidelinks <- as.character(xml2::xml_find_all(sidebar, ".//a"))
-  expect_match(sidelinks[[1]], "href=[\"]instructor[/]key-points.html")
-  expect_match(sidelinks[[2]], "Summary and Setup")
+  sidelinks_learner <- as.character(xml2::xml_find_all(sidebar, ".//a"))
+  expect_snapshot(writeLines(sidelinks_learner))
 
   # sections are equal
   learn_sections <- as.character(xml2::xml_find_all(learn, ".//section"))


### PR DESCRIPTION
- remove extra link generated for resources dropdown in varnish 0.2.1
- bump version; require varnish 0.2.1
- add NEWS; update docs
- quick fix for downlit shims due to 0.6.1 release

This will fix #306 