### PR TITLE
add AWS deployment workflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.8.1
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* A new workflow called `deploy-aws.yaml` has been created to deploy a site to
+  AWS when the right secrets from AWS are available. Because this workflow
+  does not affect normal use, I am relegating this to a patch release.
+
 # sandpaper 0.8.0
 
 CONTINUOUS INTEGRATION

--- a/inst/workflows/README.md
+++ b/inst/workflows/README.md
@@ -49,6 +49,16 @@ the `renv.lock` file, respectively. If there is a problem with the cache,
 manual invaliation is necessary and can be done by setting the `CACHE_VERSION`
 secret to the current date.
 
+### Deploy to AWS (deploy-aws.yaml)
+
+If you have an AWS bucket that is set up to deploy the site from a folder, this
+workflow will deploy the site to that folder after `01 Build and Deploy` runs.
+It can also be triggered manually.
+
+Note: for this to work, you must have the `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`,
+and `AWS_SECRET_ACCESS_KEY` in your repository secrets. If any of these are
+missing, the workflow will not run.
+
 ## Updates
 
 ### Setup Information
@@ -56,7 +66,7 @@ secret to the current date.
 These workflows run on a schedule and at the maintainer's request. Because they
 create pull requests that update workflows/require the downstream actions to run,
 they need a special repository/organization secret token called 
-`SANDPAPER_WORKFLOW` and it must have the `repo` and `workflow` scope. 
+`SANDPAPER_WORKFLOW` and it must have the `public_repo` and `workflow` scope. 
 
 This can be an individual user token, OR it can be a trusted bot account. If you
 have a repository in one of the official Carpentries accounts, then you do not
@@ -64,7 +74,7 @@ need to worry about this token being present because the Carpentries Core Team
 will take care of supplying this token.
 
 If you want to use your personal account: you can go to 
-<https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token>
+<https://github.com/settings/tokens/new?scopes=public_repo,workflow&description=Sandpaper%20Token>
 to create a token. Once you have created your token, you should copy it to your
 clipboard and then go to your repository's settings > secrets > actions and
 create or edit the `SANDPAPER_WORKFLOW` secret, pasting in the generated token.

--- a/inst/workflows/deploy-aws.yaml
+++ b/inst/workflows/deploy-aws.yaml
@@ -1,0 +1,51 @@
+name: "Deploy to AWS"
+
+on:
+  workflow_run:
+    workflows: ["01 Build and Deploy Site"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: "Preflight Check"
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check.outputs.ok }}
+      folder: ${{ steps.check.outputs.folder }}
+    steps:
+      - id: check
+        run: |
+          if [[ -z "${{ secrets.AWS_S3_BUCKET }}" || -z "${{ secrets.AWS_ACCESS_KEY_ID }}" || -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]]; then
+            echo ":information_source: No site configured" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To deploy on AWS, you need the `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` secrets set up" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "::set-output name=folder::"$(sed -E 's^.+/(.+)^\1^' <<< ${{ github.repository }})
+            echo "::set-output name=ok::true"
+          fi
+    
+  full-build:
+    name: "Deploy to AWS"
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.ok }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: "Checkout site folder"
+        uses: actions/checkout@v3
+        with:
+          ref: 'gh-pages'
+          path: 'source'
+
+      - name: "Deploy to Bucket"
+        uses: jakejarvis/s3-sync-action@0.5.1
+        with:
+          args: --acl public-read --follow-symlinks --delete --exclude '.git/*'
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'source'
+          DEST_DIR: ${{ needs.preflight.outputs.folder }}


### PR DESCRIPTION
* A new workflow called `deploy-aws.yaml` has been created to deploy a site to
  AWS when the right secrets from AWS are available. Because this workflow
  does not affect normal use, I am relegating this to a patch release.