### PR TITLE
add `create` arg to set_config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.8.1
+Version: 0.9.0
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# sandpaper 0.8.1
+# sandpaper 0.9.0
+
+MISC
+----
+
+* `set_config()` gains the option `create`, which will create new variables if
+  they do not exist. 
 
 CONTINUOUS INTEGRATION
 ----------------------

--- a/man/set_config.Rd
+++ b/man/set_config.Rd
@@ -4,11 +4,15 @@
 \alias{set_config}
 \title{Set individual keys in a configuration file}
 \usage{
-set_config(pairs = NULL, path = ".", write = FALSE)
+set_config(pairs = NULL, create = FALSE, path = ".", write = FALSE)
 }
 \arguments{
 \item{pairs}{a named character vector with keys as the names and the new
 values as the contents}
+
+\item{create}{if \code{TRUE}, any new values in \code{pairs} will be created and
+appended; defaults to \code{FALSE}, which prevents typos from sneaking in.
+single key-pair values currently supported.}
 
 \item{path}{path to the lesson. Defaults to the current directory.}
 

--- a/tests/testthat/_snaps/set_dropdown.md
+++ b/tests/testthat/_snaps/set_dropdown.md
@@ -47,7 +47,19 @@
       → title: Lesson Title -> title: 'test: title'
       → license: CC-BY 4.0 -> license: 'CC0'
 
+# custom keys will return an error with default
+
+    `set_config()`: Unknown keys
+
 # custom keys can be modified by set_config()
+
+    Code
+      set_config(c(`test-key` = "hey!"), path = tmp, write = TRUE, create = TRUE)
+    Message
+      i Writing to '[redacted]/lesson-example/config.yaml'
+      > NA -> test-key: 'hey!'
+
+---
 
     Code
       set_config(c(`test-key` = "!yeh"), path = tmp, write = TRUE)

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -30,15 +30,23 @@ cli::test_that_cli("set_config() will write items", {
 })
 
 
+test_that("custom keys will return an error with default", {
+  suppressMessages({
+  expect_snapshot_error(
+    set_config(c("test-key" = "hey!", "keytest" = "yo?"), 
+      path = tmp, write = TRUE, create = FALSE)
+  )
+  })
+})
+
 
 test_that("custom keys can be modified by set_config()", {
-  writeLines(c("test-key: 'hey!'", readLines(fs::path(tmp, "config.yaml"))),
-    fs::path(tmp, "config.yaml"))
+  expect_snapshot(set_config(c("test-key" = "hey!"), path = tmp, write = TRUE, create = TRUE),
+    transform = function(s) mask_tmpdir(s, dirname(tmp)))
   expect_equal(get_config(tmp)[["test-key"]], "hey!")
   expect_snapshot(set_config(c("test-key" = "!yeh"), path = tmp, write = TRUE),
     transform = function(s) mask_tmpdir(s, dirname(tmp)))
   expect_equal(get_config(tmp)[["test-key"]], "!yeh")
-  expect_equal(readLines(fs::path(tmp, "config.yaml"), n = 1L), "test-key: '!yeh'")
 })
 
 test_that("schedule is empty by default", {


### PR DESCRIPTION

This adds `create = FALSE` to the function signature for `set_config()`. Setting
this to `TRUE` allows programmatic creation of new key/value pairs in the config.
This will allow me to add `workbench_beta` to the config easier.
