### PR TITLE
fix fencepost bug in set_dropdown

### DIFF
--- a/R/set_dropdown.R
+++ b/R/set_dropdown.R
@@ -102,9 +102,9 @@ set_config <- function(pairs = NULL, create = FALSE, path = ".", write = FALSE) 
   if (create) {
     appends <- what == -9L
     if (any(appends)) {
-      start <- length(l) + 1L
-      end <- start + length(what[!appends])
-      what[appends] <- seq(from = start, to = end)
+      start <- length(l)
+      end <- start + length(what[appends])
+      what[appends] <- seq(from = start + 1L, to = end)
     }
   } else {
     toss <- what == 0


### PR DESCRIPTION
I've been getting this warning:

```
Warning message:
In what[appends] <- seq(from = start, to = end) :
  number of items to replace is not a multiple of replacement length
```

Turned out to be a fencepost error where I was overshooting by a single number 