### PR TITLE
allow custom index title

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.10.0
+Version: 0.10.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ NEW FEATURES
 
 * If the `index.md (or Rmd)` file has a `title` YAML element, this will take
   precedence over the default title of "Summary and Setup". 
-  (requested: @SaraMorsey, #339; fixed: @zkamvar #342)
+  (requested: @SaraMorsy, #339; fixed: @zkamvar #342)
 
 BUG FIX
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# sandpaper 0.10.1
+
+NEW FEATURES
+------------
+
+* If the `index.md (or Rmd)` file has a `title` YAML element, this will take
+  precedence over the default title of "Summary and Setup". 
+  (requested: @SaraMorsey, #339; fixed: @zkamvar #342)
+
+BUG FIX
+-------
+
+* Titles in navigation bar now have Markdown parsed correctly.
+
 # sandpaper 0.10.0
 
 NEW FEATURES

--- a/R/build_home.R
+++ b/R/build_home.R
@@ -23,14 +23,18 @@ build_home <- function(pkg, quiet, sidebar = NULL, new_setup = TRUE, next_page =
 
   nav <- get_nav_data(idx_file, fs::path_file(idx_file), page_forward = next_page)
 
-  nav$pagetitle <- "Summary and Schedule"
+  if (nav$pagetitle == "") {
+    nav$pagetitle <- "Summary and Schedule"
+  }
   nav$page_forward <- as_html(nav$page_forward, instructor = TRUE)
   page_globals$instructor$update(nav)
   page_globals$instructor$set("syllabus", paste(syl, collapse = ""))
   page_globals$instructor$set("readme", use_instructor(html))
   page_globals$instructor$set("setup", use_instructor(setup))
 
-  nav$pagetitle <- "Summary and Setup"
+  if (nav$pagetitle == "") {
+    nav$pagetitle <- "Summary and Setup"
+  }
   nav$page_forward <- as_html(nav$page_forward)
   page_globals$learner$update(nav)
   page_globals$learner$set("readme", use_learner(html))

--- a/R/utils-sidebar.R
+++ b/R/utils-sidebar.R
@@ -122,7 +122,7 @@ create_sidebar <- function(chapters, name = "", html = "<a href='https://carpent
     position <- if (name == chapters[i]) "current" else i
     info <- get_navbar_info(chapters[i])
     page_link <- paste0("<a href='", info$href, "'>", 
-      i - 1, ". ", info$pagetitle, 
+      i - 1, ". ", parse_title(info$pagetitle), 
       "</a>")
     res[i] <- create_sidebar_item(html, page_link, position)
   }

--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -65,9 +65,18 @@ set_globals <- function(path) {
   idx <- these_resources[["."]]
   idx <- idx[as_html(idx) == "index.html"]
   instructor_sidebar <- create_sidebar(c(idx, these_resources[["episodes"]]))
+  # check if we have a title in the index sidebar and replace with 
+  # "summary and schedule" if it does not exist.
+  idx_item <- xml2::read_html(instructor_sidebar[[1]])
+  idx_link <- xml2::xml_find_first(idx_item, ".//a")
+  idx_text <- xml2::xml_contents(idx_link)
+  if (length(idx_text) == 1 && xml2::xml_text(idx_text) == "0. ") {
+    xml2::xml_set_text(idx_link, "Summary and Schedule")
+  } else {
+    xml2::xml_set_text(idx_text, sub("^0[.] ", "", xml2::xml_text(idx_text)))
+  }
+  sindex <- create_sidebar_item(nodes = NULL, as.character(idx_link), 1)
   learner_sidebar <- instructor_sidebar
-  sindex <- create_sidebar_item(nodes = NULL,
-    "<a href='index.html'>Summary and Schedule</a>", 1)
   instructor_sidebar[[1]] <- sindex
   learner_sidebar[[1]] <- sub("Schedule", "Setup", sindex)
 

--- a/tests/testthat/_snaps/build_html.md
+++ b/tests/testthat/_snaps/build_html.md
@@ -36,7 +36,7 @@
       writeLines(sidelinks_instructor)
     Output
       <a href="../profiles.html">Learner View</a>
-      <a href="index.html">Summary and Schedule</a>
+      <a href="index.html"><strong>TEST</strong> title</a>
       <a href="introduction.html">1. introduction</a>
       <a href="../instructor/key-points.html">Key Points</a>
       <a href="../instructor/instructor-notes.html">Instructor Notes</a>
@@ -49,7 +49,7 @@
       writeLines(sidelinks_learner)
     Output
       <a href="instructor/profiles.html">Instructor View</a>
-      <a href="index.html">Summary and Setup</a>
+      <a href="index.html"><strong>TEST</strong> title</a>
       <a href="introduction.html">1. introduction</a>
       <a href="key-points.html">Key Points</a>
       <a href="reference.html#glossary">Glossary</a>

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -1,5 +1,8 @@
 res <- restore_fixture()
 withr::defer(clear_globals())
+idx <- readLines(fs::path(res, "index.md"))
+writeLines(c(idx[1], "title: '**TEST** title'", idx[-1]), 
+  fs::path(res, "index.md"))
 set_globals(res)
 pkg <- pkgdown::as_pkgdown(path_site(res))
 # shim for downlit ----------------------------------------------------------
@@ -32,9 +35,18 @@ test_that("[build_home()] works independently", {
   expect_true(fs::file_exists(learn_index))
   idx <- xml2::read_html(learn_index)
   expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='setup'])"))
+  newtitle <- xml2::xml_find_first(idx, ".//span[@class='current-chapter']/*")
+  expect_identical(as.character(newtitle), "<strong>TEST</strong>")
+  newtitle <- xml2::xml_find_first(idx, ".//h1/*")
+  expect_identical(as.character(newtitle), "<strong>TEST</strong>")
+
   instruct_index <- fs::path(pkg$dst_path, "instructor", "index.html")
   expect_true(fs::file_exists(instruct_index))
   idx <- xml2::read_html(instruct_index)
+  newtitle <- xml2::xml_find_first(idx, ".//span[@class='current-chapter']/*")
+  expect_identical(as.character(newtitle), "<strong>TEST</strong>")
+  newtitle <- xml2::xml_find_first(idx, ".//h1/*")
+  expect_identical(as.character(newtitle), "<strong>TEST</strong>")
   expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='setup'])"))
   expect_true(xml2::xml_find_lgl(idx, "boolean(.//main/section[@id='schedule'])"))
 })


### PR DESCRIPTION
This update allows authors to specify a custom `title` yaml item in `index.md` to override the default
"Summary and Setup" in the case where a setup is not needed for the lesson.



This will fix #340 and address #339

