### PR TITLE
add hint to interactive functions (to fix #345)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.10.4
+Version: 0.10.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# sandpaper 0.10.5
+
+NEW FEATURES
+------------
+
+* Interactive functions to modify lesson structure (`move_episode()`, 
+  `set_episode()`, etc) will now display a message if the user does not specify
+  `write = TRUE`. This message will present a command that, when executed, will
+  make the desired change (requested: @tobyhodges, #345, fixed: @zkamvar, #352)
+
 # sandpaper 0.10.4
 
 BUG FIX

--- a/R/move_episode.R
+++ b/R/move_episode.R
@@ -115,7 +115,7 @@ move_episode <- function(ep = NULL, position = NULL, write = FALSE, path = ".") 
   }
   new <- c(eps[first], ep, eps[last])
   set_dropdown(path = path, order = new, write = write, folder = "episodes")
-  show_write_hint(match.call(), additions = list(position = position))
+  show_write_hint(match.call(), additions = list(position = as.numeric(position)))
 }
 
 #' Have user select position for an episode from a list

--- a/R/move_episode.R
+++ b/R/move_episode.R
@@ -114,7 +114,8 @@ move_episode <- function(ep = NULL, position = NULL, write = FALSE, path = ".") 
     last <- seq(position, n)
   }
   new <- c(eps[first], ep, eps[last])
-  set_episodes(path = path, order = new, write = write)
+  set_dropdown(path = path, order = new, write = write, folder = "episodes")
+  show_write_hint(match.call(), additions = list(position = position))
 }
 
 #' Have user select position for an episode from a list
@@ -191,7 +192,6 @@ strip_prefix <- function(path = ".", write = FALSE) {
       fs::path(epathodes, moved_episodes))
     return(set_episodes(path = path, order = moved_episodes, write = TRUE))
   } else {
-    the_call <- match.call()
     thm <- cli::cli_div(theme = sandpaper_cli_theme())
     on.exit(cli::cli_end(thm))
     cli::cli_alert_info("Stripped prefixes")
@@ -199,10 +199,6 @@ strip_prefix <- function(path = ".", write = FALSE) {
     for (i in seq(moved_episodes)) {
       cli::cli_li("{.file {scheduled_episodes[i]}}\t->\t{.file {moved_episodes[i]}}")
     }
-    the_call[["write"]] <- TRUE
-    cll <- gsub("\\s+", " ", paste(utils::capture.output(the_call), collapse = ""))
-    cli::cli_rule()
-    cli::cli_alert_info("To save this configuration, use\n\n{.code {cll}}")
-    return(invisible(the_call))
+    show_write_hint(match.call())
   }
 }

--- a/R/set_dropdown.R
+++ b/R/set_dropdown.R
@@ -61,7 +61,6 @@ set_dropdown <- function(path = ".", order = NULL, write = FALSE, folder) {
   } else {
     show_changed_yaml(sched, order, yaml, folder)
   }
-  invisible()
 }
 
 #' Set individual keys in a configuration file
@@ -209,10 +208,7 @@ set_config <- function(pairs = NULL, create = FALSE, path = ".", write = FALSE) 
       }
       cli::cli_text(c(cli::col_yellow("+ "), line[i]))
     }
-    the_call[["write"]] <- TRUE
-    cll <- gsub("\\s+", " ", paste(utils::capture.output(the_call), collapse = ""))
-    cli::cli_alert_info("To save this configuration, use\n\n{.code {cll}}")
-    return(invisible(the_call))
+    show_write_hint(match.call())
   }
 }
 
@@ -221,23 +217,27 @@ set_config <- function(pairs = NULL, create = FALSE, path = ".", write = FALSE) 
 #' @rdname set_dropdown
 set_episodes <- function(path = ".", order = NULL, write = FALSE) {
   set_dropdown(path, order, write, "episodes")
+  show_write_hint(match.call())
 }
 
 #' @export
 #' @rdname set_dropdown
 set_learners <- function(path = ".", order = NULL, write = FALSE) {
   set_dropdown(path, order, write, "learners")
+  show_write_hint(match.call())
 }
 
 #' @export
 #' @rdname set_dropdown
 set_instructors <- function(path = ".", order = NULL, write = FALSE) {
   set_dropdown(path, order, write, "instructors")
+  show_write_hint(match.call())
 }
 
 #' @export
 #' @rdname set_dropdown
 set_profiles <- function(path = ".", order = NULL, write = FALSE) {
   set_dropdown(path, order, write, "profiles")
+  show_write_hint(match.call())
 }
 

--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -66,8 +66,26 @@ show_changed_yaml <- function(sched, order, yaml, what = "episodes") {
       cli::cli_li("{cli::style_italic(i)}")
     }
     cli::cli_end(lid)
-
   }
+
+}
+
+show_write_hint <- function(the_call = NULL, write = "write", additions = list(), which = 1) {
+  if (is.null(the_call)) {
+    return(invisible(the_call))
+  }
+  should_write <- the_call[[write]]
+  if (identical(should_write, TRUE)) {
+    return(invisible(the_call))
+  }
+  the_call[[write]] <- TRUE
+  for (a in names(additions)) {
+    the_call[[a]] <- additions[[a]]
+  }
+  cll <- gsub("\\s+", " ", paste(utils::capture.output(the_call), collapse = ""))
+  cli::cli_rule()
+  cli::cli_alert_info("To save this configuration, use\n\n{.code {cll}}")
+  return(invisible(the_call))
 }
 
 message_default_draft <- function(subfolder) {

--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -84,7 +84,7 @@ show_write_hint <- function(the_call = NULL, write = "write", additions = list()
   }
   cll <- gsub("\\s+", " ", paste(utils::capture.output(the_call), collapse = ""))
   cli::cli_rule()
-  cli::cli_alert_info("To save this configuration, use\n\n{.code {cll}}")
+  cli::cli_alert_info("To save this configuration, use\n\n{cll}")
   return(invisible(the_call))
 }
 

--- a/tests/testthat/_snaps/create_episode.md
+++ b/tests/testthat/_snaps/create_episode.md
@@ -10,7 +10,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `strip_prefix(path = tmp, write = TRUE)`
+      strip_prefix(path = tmp, write = TRUE)
 
 ---
 

--- a/tests/testthat/_snaps/move_episode.md
+++ b/tests/testthat/_snaps/move_episode.md
@@ -141,6 +141,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
 
 ---
 
@@ -153,6 +157,10 @@
       - new-too.Rmd
       - introduction.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -165,6 +173,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
 
 # Episodes can be moved to a different position [ansi]
 
@@ -177,6 +189,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
 
 ---
 
@@ -189,6 +205,10 @@
       - new-too.Rmd
       - introduction.Rmd
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -201,6 +221,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
 
 # Episodes can be moved to a different position [unicode]
 
@@ -213,6 +237,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
 
 ---
 
@@ -225,6 +253,10 @@
       - new-too.Rmd
       - introduction.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -237,6 +269,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
 
 # Episodes can be moved to a different position [fancy]
 
@@ -249,6 +285,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
 
 ---
 
@@ -261,6 +301,10 @@
       - new-too.Rmd
       - introduction.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -273,6 +317,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
 
 # Episodes can be moved out of position [plain]
 
@@ -286,6 +334,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - new-mewtwo-three.Rmd
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
 
 ---
 
@@ -299,6 +351,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - new-mewtwo-three.Rmd
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
 
 ---
 
@@ -312,6 +368,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - new-mewtwo-three.Rmd
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
 
 # Episodes can be moved out of position [ansi]
 
@@ -325,6 +385,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - [3mnew-mewtwo-three.Rmd[23m
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
 
 ---
 
@@ -338,6 +402,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - [3mnew-mewtwo-three.Rmd[23m
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
 
 ---
 
@@ -351,6 +419,10 @@
       
       -- Removed episodes ------------------------------------------------------------
       - [3mnew-mewtwo-three.Rmd[23m
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
 
 # Episodes can be moved out of position [unicode]
 
@@ -364,6 +436,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - new-mewtwo-three.Rmd
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
 
 ---
 
@@ -377,6 +453,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - new-mewtwo-three.Rmd
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
 
 ---
 
@@ -390,6 +470,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - new-mewtwo-three.Rmd
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
 
 # Episodes can be moved out of position [fancy]
 
@@ -403,6 +487,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - [3mnew-mewtwo-three.Rmd[23m
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
 
 ---
 
@@ -416,6 +504,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - [3mnew-mewtwo-three.Rmd[23m
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
 
 ---
 
@@ -429,6 +521,10 @@
       
       ── Removed episodes ────────────────────────────────────────────────────────────
       - [3mnew-mewtwo-three.Rmd[23m
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
 
 # Drafts can be added to the index [plain]
 
@@ -441,6 +537,10 @@
       - new.Rmd
       - new-too.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
 
 ---
 
@@ -453,6 +553,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -465,6 +569,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
 
 ---
 
@@ -482,6 +590,10 @@
       - new.Rmd
       - new-too.Rmd
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
 
 ---
 
@@ -494,6 +606,10 @@
       - new-too.Rmd
       - [1m[36mnew-mewtwo-three.Rmd[39m[22m
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -506,6 +622,10 @@
       - new-too.Rmd
       - [1m[36mnew-mewtwo-three.Rmd[39m[22m
       
+      --------------------------------------------------------------------------------
+      [36mi[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
 
 ---
 
@@ -523,6 +643,10 @@
       - new.Rmd
       - new-too.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
 
 ---
 
@@ -535,6 +659,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -547,6 +675,10 @@
       - new-too.Rmd
       - new-mewtwo-three.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      ℹ To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
 
 ---
 
@@ -564,6 +696,10 @@
       - new.Rmd
       - new-too.Rmd
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
 
 ---
 
@@ -576,6 +712,10 @@
       - new-too.Rmd
       - [1m[36mnew-mewtwo-three.Rmd[39m[22m
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
 
 ---
 
@@ -588,6 +728,10 @@
       - new-too.Rmd
       - [1m[36mnew-mewtwo-three.Rmd[39m[22m
       
+      ────────────────────────────────────────────────────────────────────────────────
+      [36mℹ[39m To save this configuration, use
+      
+      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
 
 ---
 

--- a/tests/testthat/_snaps/move_episode.md
+++ b/tests/testthat/_snaps/move_episode.md
@@ -144,7 +144,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
+      move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)
 
 ---
 
@@ -160,7 +160,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -176,7 +176,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
+      move_episode(ep = 4, position = 3, write = TRUE, path = res)
 
 # Episodes can be moved to a different position [ansi]
 
@@ -192,7 +192,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
+      move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)
 
 ---
 
@@ -208,7 +208,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -224,7 +224,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
+      move_episode(ep = 4, position = 3, write = TRUE, path = res)
 
 # Episodes can be moved to a different position [unicode]
 
@@ -240,7 +240,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
+      move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)
 
 ---
 
@@ -256,7 +256,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -272,7 +272,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
+      move_episode(ep = 4, position = 3, write = TRUE, path = res)
 
 # Episodes can be moved to a different position [fancy]
 
@@ -288,7 +288,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)`
+      move_episode(ep = "new-too.Rmd", position = 3, write = TRUE, path = res)
 
 ---
 
@@ -304,7 +304,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "introduction.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -320,7 +320,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = 4, position = 3, write = TRUE, path = res)`
+      move_episode(ep = 4, position = 3, write = TRUE, path = res)
 
 # Episodes can be moved out of position [plain]
 
@@ -337,7 +337,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -354,7 +354,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -371,7 +371,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
+      move_episode(ep = 3, position = 0, write = TRUE, path = res)
 
 # Episodes can be moved out of position [ansi]
 
@@ -388,7 +388,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -405,7 +405,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -422,7 +422,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
+      move_episode(ep = 3, position = 0, write = TRUE, path = res)
 
 # Episodes can be moved out of position [unicode]
 
@@ -439,7 +439,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -456,7 +456,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -473,7 +473,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
+      move_episode(ep = 3, position = 0, write = TRUE, path = res)
 
 # Episodes can be moved out of position [fancy]
 
@@ -490,7 +490,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -507,7 +507,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = FALSE, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 0, write = TRUE, path = res)
 
 ---
 
@@ -524,7 +524,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = 3, position = 0, write = TRUE, path = res)`
+      move_episode(ep = 3, position = 0, write = TRUE, path = res)
 
 # Drafts can be added to the index [plain]
 
@@ -540,7 +540,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)
 
 ---
 
@@ -556,7 +556,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -572,7 +572,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -593,7 +593,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)
 
 ---
 
@@ -609,7 +609,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -625,7 +625,7 @@
       --------------------------------------------------------------------------------
       [36mi[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -646,7 +646,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)
 
 ---
 
@@ -662,7 +662,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -678,7 +678,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       ℹ To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -699,7 +699,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 1, write = TRUE, path = res)
 
 ---
 
@@ -715,7 +715,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 
@@ -731,7 +731,7 @@
       ────────────────────────────────────────────────────────────────────────────────
       [36mℹ[39m To save this configuration, use
       
-      `move_episode(ep = "new-mewtwo-three.Rmd", position = 4L, write = TRUE, path = res)`
+      move_episode(ep = "new-mewtwo-three.Rmd", position = 4, write = TRUE, path = res)
 
 ---
 

--- a/tests/testthat/_snaps/set_dropdown.md
+++ b/tests/testthat/_snaps/set_dropdown.md
@@ -10,7 +10,7 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `set_config(pairs = list(title = "test: title", license = "CC0"), path = tmp, write = TRUE)`
+      set_config(pairs = list(title = "test: title", license = "CC0"), path = tmp, write = TRUE)
 
 # set_config() will write items [plain]
 
@@ -89,5 +89,5 @@
       --------------------------------------------------------------------------------
       i To save this configuration, use
       
-      `set_episodes(path = tmp, order = s[1], write = TRUE)`
+      set_episodes(path = tmp, order = s[1], write = TRUE)
 

--- a/tests/testthat/_snaps/set_dropdown.md
+++ b/tests/testthat/_snaps/set_dropdown.md
@@ -7,6 +7,7 @@
       + title: 'test: title'
       - license: 'CC-BY 4.0'
       + license: 'CC0'
+      --------------------------------------------------------------------------------
       i To save this configuration, use
       
       `set_config(pairs = list(title = "test: title", license = "CC0"), path = tmp, write = TRUE)`
@@ -85,4 +86,8 @@
       
       -- Removed episodes ------------------------------------------------------------
       - new.Rmd
+      --------------------------------------------------------------------------------
+      i To save this configuration, use
+      
+      `set_episodes(path = tmp, order = s[1], write = TRUE)`
 

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -54,7 +54,8 @@ test_that("schedule is empty by default", {
   cfg <- get_config(tmp)
   suppressMessages(s <- get_episodes(tmp))
   expect_equal(s, "introduction.Rmd", ignore_attr = TRUE)
-  expect_null(set_episodes(tmp, s, write = TRUE))
+  # The output of set_episodes is a call object
+  expect_type(set_episodes(tmp, s, write = TRUE), "language")
   expect_silent(s <- get_episodes(tmp))
   expect_equal(s, "introduction.Rmd", ignore_attr = TRUE)
 


### PR DESCRIPTION
This adds the internal `show_write_hint()` function, which will display a message underneath any of the interactive modification commands that will give the command to write the output:

For example, if the user provides:

```r
move_episode("introduction.Rmd")
```

and then selects `4`, the output will show the new order of the episodes followed by this message:

      --------------------------------------------------------------------------------
      i To save this configuration, use
      
      `move_episode(ep = "introduction.Rmd", position = 4, write = TRUE)`

This will fix #345
