### PR TITLE
fix index title to be clear for learner view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ MISC
 * Documentation for automated pull requests updated to reflect bots should have
   `public_repo` scope.
 
+BUG FIX
+-------
+
+* A bug where the index page title was the same for both instructor and learner
+  view has been fixed (reported: @tobyhodges, #361; fixed @zkamvar, #366)
+
 # sandpaper 0.10.7
 
 CONTINUOUS INTEGRATION

--- a/R/build_home.R
+++ b/R/build_home.R
@@ -22,8 +22,9 @@ build_home <- function(pkg, quiet, sidebar = NULL, new_setup = TRUE, next_page =
   fix_nodes(setup)
 
   nav <- get_nav_data(idx_file, fs::path_file(idx_file), page_forward = next_page)
+  needs_title <- nav$pagetitle == ""
 
-  if (nav$pagetitle == "") {
+  if (needs_title) {
     nav$pagetitle <- "Summary and Schedule"
   }
   nav$page_forward <- as_html(nav$page_forward, instructor = TRUE)
@@ -32,7 +33,7 @@ build_home <- function(pkg, quiet, sidebar = NULL, new_setup = TRUE, next_page =
   page_globals$instructor$set("readme", use_instructor(html))
   page_globals$instructor$set("setup", use_instructor(setup))
 
-  if (nav$pagetitle == "") {
+  if (needs_title) {
     nav$pagetitle <- "Summary and Setup"
   }
   nav$page_forward <- as_html(nav$page_forward)


### PR DESCRIPTION
This changes the default learner view title to read "Summary and Setup"
There was a bug where we were checking for a condition after we had set it.


This will fix #364
