### PR TITLE
update PR workflows to use concurrency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.2
+Version: 0.11.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# sandpaper 0.11.3
+
+CONTINUOUS INTEGRATION
+----------------------
+
+* Pull Request workflows will now automatically cancel if several commits are
+  sent in succession. Specifically, the workflows `pr-recieve.yaml` and 
+  `pr-comment.yaml` are given separate `concurrency` parameters based on the
+  branch name and the pull request number. These concurrencies will prevent
+  false alarms as found in 
+  <https://github.com/carpentries/lesson-development-training/pull/165#issuecomment-1337182275>.
+  (discovered: @anenadic; reported: @zkamvar, #374; fixed: @zkamvar, #376)
+
 # sandpaper 0.11.2
 
 MISC

--- a/inst/workflows/README.md
+++ b/inst/workflows/README.md
@@ -147,6 +147,11 @@ pull request. GitHub has safeguarded the token used in this workflow to have no
 priviledges in the repository, but we have taken precautions to protect against
 spoofing.
 
+This workflow is triggered with every push to a pull request. If this workflow
+is already running and a new push is sent to the pull request, the workflow
+running from the previous push will be cancelled and a new workflow run will be
+started.
+
 The first step of this workflow is to check if it is valid (e.g. that no
 workflow files have been modified). If there are workflow files that have been
 modified, a comment is made that indicates that the workflow is not run. If 
@@ -160,7 +165,7 @@ request. This builds the content and uploads three artifacts:
 3. The rendered files (build)
 
 Because this workflow builds generated content, it follows the same general 
-process as the sandpaper-main workflow with the same caching mechanisms.
+process as the `sandpaper-main` workflow with the same caching mechanisms.
 
 The artifacts produced are used by the next workflow.
 
@@ -176,7 +181,7 @@ The steps in this workflow are:
 3. If it is valid: update the pull request comment with the summary of changes
 
 Importantly: if the pull request is invalid, the branch is not created so any
-malicious code is not published. 
+malicious code is not published.
 
 From here, the maintainer can request changes from the author and eventually 
 either merge or reject the PR. When this happens, if the PR was valid, the 

--- a/inst/workflows/pr-comment.yaml
+++ b/inst/workflows/pr-comment.yaml
@@ -63,6 +63,7 @@ jobs:
         with:
           pr: ${{ steps.get-pr.outputs.NUM }}
           sha: ${{ github.event.workflow_run.head_sha }}
+          headroom: 3 # if it's within the last three commits, we can keep going, because it's likely rapid-fire
           invalid: ${{ fromJSON(steps.hash.outputs.json)[github.repository] }}
           fail_on_error: true
 

--- a/inst/workflows/pr-comment.yaml
+++ b/inst/workflows/pr-comment.yaml
@@ -8,6 +8,11 @@ on:
     types:
       - completed
 
+concurrency:
+  group: pr-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
+
+
 jobs:
   # Pull requests are valid if:
   #  - they match the sha of the workflow run head commit

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -5,6 +5,10 @@ on:
     types:
       [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-pr:
     name: "Record PR number"


### PR DESCRIPTION
The pr-recieve and pr-comment workflows now use concurrencey <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency> to cancel in-progress workflow runs if a new workflow run is started. This will prevent situations like <https://github.com/carpentries/lesson-development-training/pull/165#issuecomment-1337182275> from happening.

This PR will fix #374
