### PR TITLE
update for pandoc 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.3
+Version: 0.11.4
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -21,7 +21,7 @@ Description: We provide tools to build a Carpentries-themed lesson repository
   those designed to be used in a continuous integration context so that all the
   lesson author needs to focus on is writing the content of the actual lesson.
 License: MIT + file LICENSE
-Imports: 
+Imports:
     pkgdown (>= 1.6.0),
     pegboard (>= 0.2.3),
     cli (>= 3.4.0),
@@ -45,7 +45,7 @@ Imports:
     servr,
     utils,
     tools
-Suggests: 
+Suggests:
     testthat (>= 3.0.0),
     markdown,
     brio,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.11.4
+
+PANDOC
+------
+
+* This updates {sandaper} to be used by pandoc version 3, which no longer
+  implements the `pandoc.Null()` constructor for Lua filters (reported:
+  @zkamvar, #380; fixed: @zkamvar: #385)
+
 # sandpaper 0.11.3
 
 CONTINUOUS INTEGRATION

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -140,7 +140,7 @@ clean_branch <- function(repo, branch = NULL, name = "sandpaper-local", verbose 
   gert::git_branch_delete(branch, repo = repo)
   rmt_url <- gert::git_remote_list(repo)
   rmt_url <- rmt_url$url[rmt_url$name == name]
-  if (length(rmt_url) > 0) { 
+  if (length(rmt_url) > 0) {
     gert::git_branch_delete(branch, repo = rmt_url)
   }
 }
@@ -150,8 +150,8 @@ clean_branch <- function(repo, branch = NULL, name = "sandpaper-local", verbose 
 #' ## `remove_local_remote()`
 #'
 #' Destorys the local remote repository and removes it from the fixture lesson
-#' 
-#' @return (`remove_local_remote()`) FALSE indicating an error or a string 
+#'
+#' @return (`remove_local_remote()`) FALSE indicating an error or a string
 #'   indicating the path to the remote
 #' @rdname fixtures
 remove_local_remote <- function(repo, name = "sandpaper-local") {
@@ -159,13 +159,23 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
     return(repo)
   }
   remotes <- tryCatch(gert::git_remote_list(repo = repo),
-    error = function(e) data.frame(name = character(0))
+    error = function(e) {
+      e$message <- paste0("error from within: ", e$message)
+      d <- data.frame(name = character(0))
+      return(d)
+    }
   )
   if (any(the_remote <- remotes$name %in% name)) {
     gert::git_remote_remove(name, repo)
     to_remove <- remotes$url[the_remote]
     # don't error if we can not delete this.
-    return(tryCatch(fs::dir_delete(to_remove), error = function() FALSE))
+    res <- tryCatch(fs::dir_delete(to_remove),
+      error = function(e) {
+        e$message <- paste0("error from within: ", e$message)
+        return(FALSE)
+      }
+    )
+    return(res)
   }
   return(invisible("(no remote present)"))
 }

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -55,7 +55,7 @@ end
 --
 -- This was originally taken care of by Jekyll, but since we are not necessarily
 -- relying on a logic-based templating language (liquid can diaf), we can create
--- this here. 
+-- this here.
 --
 --]]
 function overview_card()
@@ -70,9 +70,9 @@ function overview_card()
   local overview = pandoc.Div({}, {class="overview card"})
   -- create headers. Note because of --section-divs, we have to insert raw
   -- headers so that the divs do not inherit the header classes afterwards
-  table.insert(questions_div.content, 
+  table.insert(questions_div.content,
   pandoc.RawBlock("html", "<h3 class='card-title'>Questions</h3>"))
-  table.insert(objectives_div.content, 
+  table.insert(objectives_div.content,
   pandoc.RawBlock("html", "<h3 class='card-title'>Objectives</h3>"))
 
   -- Insert the content from the objectives and the questions
@@ -92,9 +92,9 @@ function overview_card()
   table.insert(obody.content, objectives_div)
   table.insert(qcol.content, qbody)
   table.insert(ocol.content, obody)
-  table.insert(row.content, qcol) 
-  table.insert(row.content, ocol) 
-  table.insert(overview.content, 
+  table.insert(row.content, qcol)
+  table.insert(row.content, ocol)
+  table.insert(overview.content,
   pandoc.RawBlock("html", "<h2 class='card-header'>Overview</h2>"))
   table.insert(overview.content, row)
   table.insert(res, overview)
@@ -126,7 +126,7 @@ function get_header(el, level)
 end
 
 -- Add a header to a Div element if it doesn't exist
--- 
+--
 -- @param el a pandoc.Div element
 -- @param level an integer specifying the level of the header
 --
@@ -222,7 +222,7 @@ accordion = function(el, class)
 
   -- constructing the button that contains a heading
   local this_button = accordion_button
-  this_button = this_button:gsub("{{heading}}", button_headings[class]) 
+  this_button = this_button:gsub("{{heading}}", button_headings[class])
   this_button = this_button:gsub("{{title}}", title)
   this_button = this_button:gsub("{{class}}", class)
   this_button = this_button:gsub("{{id}}", label)
@@ -270,7 +270,7 @@ callout_block = function(el)
   classes:insert(1, "callout")
   local header = get_header(el, 3)
 
-  local icon = pandoc.RawBlock("html", 
+  local icon = pandoc.RawBlock("html",
   "<i class='callout-icon' data-feather='"..this_icon.."'></i>")
   local callout_square = pandoc.Div(icon, {class = "callout-square"})
 
@@ -301,7 +301,7 @@ challenge_block = function(el)
   -- This challenge is a placeholder to stuff the original challenge contents in
   local this_challenge = pandoc.Div({this_head}, {class = "challenge"})
   -- Indicator if the challenge block should be inserted before the accordion.
-  -- Once we hit an accordion block, we no longer need the challenge inserted 
+  -- Once we hit an accordion block, we no longer need the challenge inserted
   -- and any new challenge items go in a new block
   local needs_challenge = true
   for idx, block in ipairs(el.content) do
@@ -314,7 +314,7 @@ challenge_block = function(el)
       challenge_train:insert(block)
     else
       if block.t == "Header" and #this_challenge.content == 1 then
-        -- if we started a new challenge block and it already has a header, 
+        -- if we started a new challenge block and it already has a header,
         -- then we need to remove our continuation header
         this_challenge.content:remove(1)
       end
@@ -339,8 +339,8 @@ handle_our_divs = function(el)
     questions = el
     if objectives ~= nil then
       return overview_card()
-    else 
-      return pandoc.Null()
+    else
+      return pandoc.RawBlock("text", "")
     end
   end
 
@@ -349,8 +349,8 @@ handle_our_divs = function(el)
     objectives = el
     if questions ~= nil then
       return overview_card()
-    else 
-      return pandoc.Null()
+    else
+      return pandoc.RawBlock("text", "")
     end
   end
 
@@ -394,7 +394,7 @@ end
 --
 -- 1. removes any leading ../[folder]/ from the links to prepare them for the
 --    way the resources appear in the HTML site
--- 2. renames all local Rmd and md files to .html 
+-- 2. renames all local Rmd and md files to .html
 --
 -- NOTE: it _IS_ possible to use variable expansion with this so that we can
 --       configure this to do specific things (e.g. decide how we want the

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -3,7 +3,7 @@
     Code
       cat(readLines(out), sep = "\n")
     Output
-      [Null
+      [RawBlock (Format "text") ""
       ,Div ("",["overview","card"],[])
        [RawBlock (Format "html") "<h2 class='card-header'>Overview</h2>"
        ,Div ("",["row","g-0"],[])
@@ -52,7 +52,7 @@
     Code
       cat(readLines(out), sep = "\n")
     Output
-      [Null
+      [RawBlock (Format "text") ""
       ,Div ("",["overview","card"],[])
        [RawBlock (Format "html") "<h2 class='card-header'>Overview</h2>"
        ,Div ("",["row","g-0"],[])


### PR DESCRIPTION
This updates the lua filter so that it no longer uses the [removed `pandoc.Null()` constructor](https://github.com/jgm/pandoc-types/issues/91).

This will have no user-visible effect other than allowing those using pandoc 3 to render their lessons.

This will fix #380 