### PR TITLE
fix update_cache() and pin_version() to use root directory. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.4
+Version: 0.11.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# sandpaper 0.11.5
+
+BUG FIX
+-------
+
+* `update_cache()` and `pin_version()` will now find the root path of the
+  lesson before checking and manipulating dependencies. This will circumvent
+  the issue where a user could accidentally create a `episodes/renv` folder by
+  running `update_cache()` from the `episodes/` directory (discovered:
+  @sarahkaspar; reported: @zkamvar, #391; fixed: @zkamvar, #392).
+
 # sandpaper 0.11.4
 
 BUG FIX

--- a/R/manage_deps.R
+++ b/R/manage_deps.R
@@ -34,7 +34,7 @@
 #'   Carpentries lessons are also working academics and will likely have
 #'   projects on their computer where the package versions are necessary for
 #'   their work, it's important that those environments are respected.
-#'  
+#'
 #'   Our flavor of {renv} applies a package cache explicitly to the content of
 #'   the lesson, but does not impose itself as the default {renv} environment.
 #'
@@ -105,6 +105,7 @@ manage_deps <- function(path = ".", profile = "lesson-requirements", snapshot = 
 #' @rdname dependency_management
 #' @export
 update_cache <- function(path = ".", profile = "lesson-requirements", prompt = interactive(), quiet = !prompt, snapshot = TRUE) {
+  path <- root_path(path)
   prof <- Sys.getenv("RENV_PROFILE")
   on.exit({
     invisible(utils::capture.output(renv::deactivate(path), type = "message"))
@@ -140,15 +141,15 @@ update_cache <- function(path = ".", profile = "lesson-requirements", prompt = i
 #' Pin a resource to a specific version
 #'
 #' This is a wrapper around [renv::record()], which helps you record a package
-#' or set of packages in your lockfile. It can be useful when you want to 
-#' upgrade or downgrade a specific package. 
+#' or set of packages in your lockfile. It can be useful when you want to
+#' upgrade or downgrade a specific package.
 #'
 #' @param records a character vector or list of packages/resources to include
 #' in the lockfile. The most common way to do this is to use the
 #' `[package]@[version]` syntax (e.g. `gert@0.1.3`), but there are other
 #' specifications where you can specify the remote repository. See
 #' [renv::record()] for details.
-#' @param profile default to the profile for the lesson. Defaults to 
+#' @param profile default to the profile for the lesson. Defaults to
 #' `lesson-requirements`. Only use this if you know what you are doing.
 #' @param path path to your lesson. Defaults to the current working directory.
 #'

--- a/R/manage_deps.R
+++ b/R/manage_deps.R
@@ -164,6 +164,7 @@ pin_version <- function(records = NULL, profile = "lesson-requirements", path = 
     Sys.setenv("RENV_PROFILE" = prof)
     setwd(wd)
   })
+  path <- root_path(path)
   setwd(path)
   Sys.setenv("RENV_PROFILE" = profile)
   lockfile <- renv::paths$lockfile(project = path)

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -51,7 +51,7 @@ test_that("manage_deps() will create a renv folder", {
   fs::file_move(rnv, tmp)
   withr::defer({
     fs::dir_delete(rnv)
-    fs::file_move(fs::path(tmp, "renv"), rnv) 
+    fs::file_move(fs::path(tmp, "renv"), rnv)
   })
   expect_false(fs::dir_exists(rnv))
 
@@ -64,8 +64,8 @@ test_that("manage_deps() will create a renv folder", {
 
   expect_true(fs::dir_exists(rnv))
   expect_false(
-    renv_should_rebuild(lsn, 
-      rebuild = FALSE, 
+    renv_should_rebuild(lsn,
+      rebuild = FALSE,
       db_path = fs::path(path_built(lsn), "md5sum.txt")
     )
   )
@@ -83,9 +83,9 @@ test_that("manage_deps() will run without callr", {
   ))
 
   suppressMessages({
-  callr_manage_deps(lsn, 
-    repos = renv_carpentries_repos(), 
-    snapshot = TRUE, 
+  callr_manage_deps(lsn,
+    repos = renv_carpentries_repos(),
+    snapshot = TRUE,
     lockfile_exists = TRUE) %>%
     expect_message("Restoring any dependency versions") %>%
     expect_output("package dependencies")
@@ -96,16 +96,16 @@ test_that("manage_deps() will run without callr", {
 
 
 test_that("renv will not trigger a rebuild when nothing changes", {
-  
+
   skip_on_cran()
   skip_on_os("windows")
   # nothing changes, so we do not rebuild
   db_path <- fs::path(path_built(lsn), "md5sum.txt")
   profile <- "lesson-requirements"
-  
+
   expect_false(
-    renv_should_rebuild(lsn, 
-      rebuild = FALSE, 
+    renv_should_rebuild(lsn,
+      rebuild = FALSE,
       db_path = fs::path(path_built(lsn), "md5sum.txt")
     )
   )
@@ -123,7 +123,7 @@ test_that("renv will not trigger a rebuild when nothing changes", {
 
 
 test_that("pin_version() will use_specific versions", {
-  
+
   skip_on_cran()
   skip_on_os("windows")
   skip_if_offline()
@@ -161,7 +161,7 @@ test_that("Package cache changes will trigger a rebuild", {
   # nothing changes, so we do not rebuild
   db_path <- fs::path(path_built(lsn), "md5sum.txt")
   profile <- "lesson-requirements"
-  
+
   # default: no rebuilding
   expect_false(renv_should_rebuild(lsn, rebuild = FALSE, db_path = db_path))
   withr::defer(package_cache_trigger(FALSE))
@@ -191,14 +191,14 @@ test_that("Package cache changes will trigger a rebuild", {
 
 
 test_that("update_cache() will update old package versions", {
-  
+
   skip_on_cran()
   skip_on_os("windows")
   skip_if_offline()
   skip_if(covr::in_covr())
 
   suppressMessages({
-    res <- update_cache(path = lsn, prompt = FALSE, quiet = FALSE) %>%
+    res <- update_cache(path = fs::path(lsn, "episodes"), prompt = FALSE, quiet = FALSE) %>%
       expect_output("sessioninfo")
   })
   expect_true(

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -136,7 +136,7 @@ test_that("pin_version() will use_specific versions", {
 
   writeLines("library(sessioninfo)", con = fs::path(lsn, "episodes", "si.R"))
   expect_output({
-    pin_version("sessioninfo@1.1.0", path = lsn) # old version of sessioninfo
+    pin_version("sessioninfo@1.1.0", path = fs::path(lsn, "episodes")) # old version of sessioninfo
   }, "Updated 1 record in")
 
   # Need to consider this because there is something happening inside of covr


### PR DESCRIPTION
This will fix `update_cache()` and `pin_version()` to use the root directory of the lesson, avoiding situations where a user could accidentally insert a stray `renv/` folder in one of the sub directories. 

This will fix #391 