### PR TITLE
allow blank or character timings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.5
+Version: 0.11.6
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.11.6 (in development)
+
+## NEW FEATURE
+
+* blank or character timing estimates (e.g. XX) will now be treated as unknown
+  and an estimate of 5 minutes will be used for each missing element
+  (reported: @zkamvar, #395; fixed: @zkamvar, #396)
+
 # sandpaper 0.11.5 (2023-02-09)
 
 ## BUG FIX

--- a/R/get_syllabus.R
+++ b/R/get_syllabus.R
@@ -13,8 +13,8 @@
 #' @keywords internal
 #' @export
 get_syllabus <- function(path = ".", questions = FALSE, use_built = TRUE) {
-  
-  # The home page contains three things: 
+
+  # The home page contains three things:
   # 0. The main title as a header
   # 1. the content of index.md from the top level of the lesson directory
   # 2. The computed syllabus
@@ -39,7 +39,7 @@ create_syllabus <- function(episodes, lesson, path, questions = TRUE) {
     lesson <- set_this_lesson(path)
   }
   episodes <- lesson$episodes[sched]
-  
+
   quest <- if (questions) vapply(episodes, get_questions, character(1)) else NULL
 
   timings <- vapply(episodes, get_timings, numeric(1))
@@ -47,13 +47,13 @@ create_syllabus <- function(episodes, lesson, path, questions = TRUE) {
 
   # NOTE: This assumes a flat file structure for the website.
   paths <- fs::path_ext_set(sched, "html")
-  
+
   start <- as.POSIXlt("00:00", format = "%H:%M", tz = "UTC")
   # Note: we are creating a start time of 0 and adding "Finish" to the end.
   cumulative_minutes <- cumsum(c(0, timings)) * 60L
 
   out <- data.frame(
-    episode = c(titles, "Finish"), 
+    episode = c(titles, "Finish"),
     timings = format(start + cumulative_minutes, "%Hh %Mm"),
     path = c(paths, ""),
     percents = sprintf("%1.0f", 100 * (cumulative_minutes / max(cumulative_minutes))),
@@ -72,7 +72,17 @@ get_titles <- function(ep) {
 
 get_timings <- function(ep) {
   yaml <- ep$get_yaml()
-  as.numeric(sum(yaml$teaching, yaml$exercises, na.rm = TRUE))
+  coerce_integer <- function(i, default = 5L) {
+    not_integer <- !grepl("^[0-9]+$", i)
+    # NULL will return logical(0)
+    if (length(not_integer) == 0 || not_integer) {
+      i <- default
+    }
+    return(as.integer(i))
+  }
+  teach <- coerce_integer(yaml$teaching)
+  exerc <- coerce_integer(yaml$exercises)
+  as.integer(sum(teach, exerc, na.rm = TRUE))
 }
 
 get_questions <- function(ep) {

--- a/tests/testthat/test-get_syllabus.R
+++ b/tests/testthat/test-get_syllabus.R
@@ -29,22 +29,22 @@ test_that("syllabus will update with new files", {
   expect_equal(res$episode, c("introduction", "postroduction", "Finish"))
   expect_equal(fs::path_file(res$path), c("introduction.html", "postroduction.html", ""))
   expect_equal(res$questions, c(rep(q, 2), ""))
-  
+
 })
 
-test_that("episodes missing question blocks do not throw error", {
+test_that("episodes missing question blocks and timings do not throw error", {
 
   writeLines(
-    "---\ntitle: Break\nteaching: 42\nexercises: 0\n---\n\nThis should not error.",
+    "---\ntitle: Break\nteaching: XX\n---\n\nThis should not error.",
     fs::path(tmp, "episodes", "break.md")
   )
 
   set_episodes(tmp, c(get_episodes(tmp), "break.md"), write = TRUE)
 
-  expect_warning(res <- get_syllabus(tmp, questions = TRUE))
+  expect_warning(res <- get_syllabus(tmp, questions = TRUE), "questions")
   expect_equal(nrow(res), 4)
-  expect_equal(res$timings, c("00h 00m", "00h 12m", "00h 24m", "01h 06m"))
-  expect_equal(res$percents, c("0", "18", "36", "100"))
+  expect_equal(res$timings, c("00h 00m", "00h 12m", "00h 24m", "00h 34m"))
+  expect_equal(res$percents, c("0", "35", "71", "100"))
   expect_equal(res$episode, c("introduction", "postroduction", "Break", "Finish"))
   expect_equal(fs::path_file(res$path), c("introduction.html", "postroduction.html", "break.html", ""))
   expect_equal(res$questions, c(rep(q, 2), "", ""))


### PR DESCRIPTION
For those who are developing lessons and do not wish to commit to timings, they can write:

```yaml
teaching: XX
exercises: XX
```

and {sandpaper} will insert 5 minutes as a placeholder until a better timing 
can be addressed
