### PR TITLE
fix instructor view asset links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ BUG FIX
 -------
 
 * Links to assets in instructor view no longer render a 404. (reported:
-  @sarahmbrown, #404; fixed: @zkamvar, #408)
+  @brownsarahm, #404; fixed: @zkamvar, #408)
 
 CONTINUOUS INTEGRATION
 ----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # sandpaper 0.11.9 (in development)
 
+BUG FIX
+-------
+
+* Links to assets in instructor view no longer render a 404. (reported:
+  @sarahmbrown, #404; fixed: @zkamvar, #408)
+
 CONTINUOUS INTEGRATION
 ----------------------
 

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -120,10 +120,11 @@ use_instructor <- function(nodes = NULL) {
     ".//a[@href][not(contains(@href, '://')) and not(starts-with(@href, '#'))]"
   )
   lnk_hrefs <- xml2::xml_attr(lnk, "href")
+  lnk_paths <- xml2::url_parse(lnk_hrefs)$path
   # links without HTML extension
-  not_html <- fs::path_ext(lnk_hrefs) != "html"
+  not_html <- !fs::path_ext(lnk_paths) %in% c("html", "")
   # links that are not in the root directory (e.g. files/a.html, but not ./a.html)
-  is_nested <- lengths(strsplit(sub("^[.][/]", "", lnk_hrefs), "/")) > 1
+  is_nested <- lengths(strsplit(sub("^[.][/]", "", lnk_paths), "/")) > 1
   is_above <- not_html | is_nested
   lnk_hrefs[is_above] <- fs::path("../", lnk_hrefs[is_above])
   xml2::xml_set_attr(lnk, "href", lnk_hrefs)

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -116,7 +116,9 @@ use_instructor <- function(nodes = NULL) {
   if (length(nodes) == 0) return(nodes)
   copy <- xml2::read_html(as.character(nodes))
   # find all local links and transform non-html and nested links ---------
-  lnk <- xml2::xml_find_all(copy, ".//a[not(starts-with(@href, 'http'))]")
+  lnk <- xml2::xml_find_all(copy,
+    ".//a[@href][not(contains(@href, '://')) and not(starts-with(@href, '#'))]"
+  )
   lnk_hrefs <- xml2::xml_attr(lnk, "href")
   # links without HTML extension
   not_html <- fs::path_ext(lnk_hrefs) != "html"

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -40,12 +40,12 @@ fix_codeblocks <- function(nodes = NULL) {
 add_code_heading <- function(codes = NULL, labels = "OUTPUT") {
   if (length(codes) == 0) return(codes)
   xml2::xml_set_attr(codes, "tabindex", "0")
-  heads <- xml2::xml_add_sibling(codes, "h3", labels, class = "code-label", 
+  heads <- xml2::xml_add_sibling(codes, "h3", labels, class = "code-label",
     .where = "before")
   for (head in heads) {
-    xml2::xml_add_child(head, "i", 
+    xml2::xml_add_child(head, "i",
       "aria-hidden" = "true", "data-feather" = "chevron-left")
-    xml2::xml_add_child(head, "i", 
+    xml2::xml_add_child(head, "i",
       "aria-hidden" = "true", "data-feather" = "chevron-right")
   }
   invisible(codes)
@@ -97,7 +97,7 @@ fix_setup_link <- function(nodes = NULL) {
   if (length(nodes) == 0) return(nodes)
   links <- xml2::xml_find_all(nodes, ".//a")
   hrefs <- xml2::url_parse(xml2::xml_attr(links, "href"))
-  setup_links <- hrefs$scheme == "" & 
+  setup_links <- hrefs$scheme == "" &
     hrefs$server == "" &
     hrefs$path == "setup.html"
   xml2::xml_set_attr(links[setup_links], "href", "index.html#setup")
@@ -115,9 +115,12 @@ use_learner <- function(nodes = NULL) {
 use_instructor <- function(nodes = NULL) {
   if (length(nodes) == 0) return(nodes)
   copy <- xml2::read_html(as.character(nodes))
-  # lnk <- xml2::xml_find_all(copy, ".//a[not(starts-with(@href, 'http'))]")
+  lnk <- xml2::xml_find_all(copy, ".//a[not(starts-with(@href, 'http'))]")
+  lnk_hrefs <- xml2::xml_attr(lnk, "href")
+  is_above <- fs::path_ext(lnk_hrefs) != "html"
+  lnk_hrefs[is_above] <- fs::path("../", lnk_hrefs[is_above])
+  xml2::xml_set_attr(lnk, "href", lnk_hrefs)
   img <- xml2::xml_find_all(copy, ".//img[not(starts-with(@src, 'http'))]")
-  # xml2::xml_set_attr(lnk, "href", fs::path("instructor/", xml2::xml_attr(lnk, "href")))
   xml2::xml_set_attr(img, "src", fs::path("../", xml2::xml_attr(img, "src")))
   as.character(copy)
 }

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -1,9 +1,9 @@
 # paths in instructor view that are nested or not HTML get diverted
 
     Code
-      xml2::xml_find_all(html_test, ".//a")
+      xml2::xml_find_all(html_test, ".//a[@href]")
     Output
-      {xml_nodeset (7)}
+      {xml_nodeset (8)}
       [1] <a href="index.html">a</a>
       [2] <a href="./index.html">b</a>
       [3] <a href="fig/thing.png">c</a>
@@ -11,13 +11,14 @@
       [5] <a href="data/thing.csv">e</a>
       [6] <a href="files/papers/thing.pdf">f</a>
       [7] <a href="files/confirmation.html">g</a>
+      [8] <a href="#what-the">h</a>
 
 ---
 
     Code
-      xml2::xml_find_all(res, ".//a")
+      xml2::xml_find_all(res, ".//a[@href]")
     Output
-      {xml_nodeset (7)}
+      {xml_nodeset (8)}
       [1] <a href="index.html">a</a>
       [2] <a href="./index.html">b</a>
       [3] <a href="../fig/thing.png">c</a>
@@ -25,4 +26,5 @@
       [5] <a href="../data/thing.csv">e</a>
       [6] <a href="../files/papers/thing.pdf">f</a>
       [7] <a href="../files/confirmation.html">g</a>
+      [8] <a href="#what-the">h</a>
 

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -3,24 +3,26 @@
     Code
       xml2::xml_find_all(html_test, ".//a")
     Output
-      {xml_nodeset (6)}
+      {xml_nodeset (7)}
       [1] <a href="index.html">a</a>
       [2] <a href="./index.html">b</a>
       [3] <a href="fig/thing.png">c</a>
       [4] <a href="./fig/thang.jpg">d</a>
       [5] <a href="data/thing.csv">e</a>
       [6] <a href="files/papers/thing.pdf">f</a>
+      [7] <a href="files/confirmation.html">g</a>
 
 ---
 
     Code
       xml2::xml_find_all(res, ".//a")
     Output
-      {xml_nodeset (6)}
+      {xml_nodeset (7)}
       [1] <a href="index.html">a</a>
       [2] <a href="./index.html">b</a>
       [3] <a href="../fig/thing.png">c</a>
       [4] <a href=".././fig/thang.jpg">d</a>
       [5] <a href="../data/thing.csv">e</a>
       [6] <a href="../files/papers/thing.pdf">f</a>
+      [7] <a href="../files/confirmation.html">g</a>
 

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -1,0 +1,26 @@
+# paths in instructor view that are not HTML get diverted
+
+    Code
+      xml2::xml_find_all(html_test, ".//a")
+    Output
+      {xml_nodeset (6)}
+      [1] <a href="index.html">a</a>
+      [2] <a href="./index.html">b</a>
+      [3] <a href="fig/thing.png">c</a>
+      [4] <a href="./fig/thang.jpg">d</a>
+      [5] <a href="data/thing.csv">e</a>
+      [6] <a href="files/papers/thing.pdf">f</a>
+
+---
+
+    Code
+      xml2::xml_find_all(res, ".//a")
+    Output
+      {xml_nodeset (6)}
+      [1] <a href="index.html">a</a>
+      [2] <a href="./index.html">b</a>
+      [3] <a href="../fig/thing.png">c</a>
+      [4] <a href=".././fig/thang.jpg">d</a>
+      [5] <a href="../data/thing.csv">e</a>
+      [6] <a href="../files/papers/thing.pdf">f</a>
+

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -3,28 +3,32 @@
     Code
       xml2::xml_find_all(html_test, ".//a[@href]")
     Output
-      {xml_nodeset (8)}
-      [1] <a href="index.html">a</a>
-      [2] <a href="./index.html">b</a>
-      [3] <a href="fig/thing.png">c</a>
-      [4] <a href="./fig/thang.jpg">d</a>
-      [5] <a href="data/thing.csv">e</a>
-      [6] <a href="files/papers/thing.pdf">f</a>
-      [7] <a href="files/confirmation.html">g</a>
-      [8] <a href="#what-the">h</a>
+      {xml_nodeset (10)}
+       [1] <a href="index.html">a</a>
+       [2] <a href="./index.html">b</a>
+       [3] <a href="fig/thing.png">c</a>
+       [4] <a href="./fig/thang.jpg">d</a>
+       [5] <a href="data/thing.csv">e</a>
+       [6] <a href="files/papers/thing.pdf">f</a>
+       [7] <a href="files/confirmation.html">g</a>
+       [8] <a href="#what-the">h</a>
+       [9] <a href="other-page.html#section">i</a>
+      [10] <a href="other-page">j</a>
 
 ---
 
     Code
       xml2::xml_find_all(res, ".//a[@href]")
     Output
-      {xml_nodeset (8)}
-      [1] <a href="index.html">a</a>
-      [2] <a href="./index.html">b</a>
-      [3] <a href="../fig/thing.png">c</a>
-      [4] <a href=".././fig/thang.jpg">d</a>
-      [5] <a href="../data/thing.csv">e</a>
-      [6] <a href="../files/papers/thing.pdf">f</a>
-      [7] <a href="../files/confirmation.html">g</a>
-      [8] <a href="#what-the">h</a>
+      {xml_nodeset (10)}
+       [1] <a href="index.html">a</a>
+       [2] <a href="./index.html">b</a>
+       [3] <a href="../fig/thing.png">c</a>
+       [4] <a href=".././fig/thang.jpg">d</a>
+       [5] <a href="../data/thing.csv">e</a>
+       [6] <a href="../files/papers/thing.pdf">f</a>
+       [7] <a href="../files/confirmation.html">g</a>
+       [8] <a href="#what-the">h</a>
+       [9] <a href="other-page.html#section">i</a>
+      [10] <a href="other-page">j</a>
 

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -1,4 +1,4 @@
-# paths in instructor view that are not HTML get diverted
+# paths in instructor view that are nested or not HTML get diverted
 
     Code
       xml2::xml_find_all(html_test, ".//a")

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -1,4 +1,21 @@
 
+
+test_that("paths in instructor view that are not HTML get diverted", {
+  html_test <- xml2::read_html(commonmark::markdown_html(c(
+    "[a](index.html)",
+    "[b](./index.html)",
+    "[c](fig/thing.png)",
+    "[d](./fig/thang.jpg)",
+    "[e](data/thing.csv)",
+    "[f](files/papers/thing.pdf)"
+  )))
+  res <- xml2::read_html(use_instructor(html_test))
+  expect_snapshot(xml2::xml_find_all(html_test, ".//a"))
+  expect_snapshot(xml2::xml_find_all(res, ".//a"))
+})
+
+
+
 test_that("empty args result in nothing happening", {
   expect_null(fix_nodes())
   expect_null(fix_setup_link())

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -7,9 +7,14 @@ test_that("paths in instructor view that are not HTML get diverted", {
     "[c](fig/thing.png)",
     "[d](./fig/thang.jpg)",
     "[e](data/thing.csv)",
-    "[f](files/papers/thing.pdf)"
+    "[f](files/papers/thing.pdf)",
+    "[g](files/confirmation.html)"
   )))
   res <- xml2::read_html(use_instructor(html_test))
+  # there are fo
+  refs <- xml2::xml_text(xml2::xml_find_all(res, ".//@href"))
+  expect_equal(startsWith(refs, "../"),
+    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE))
   expect_snapshot(xml2::xml_find_all(html_test, ".//a"))
   expect_snapshot(xml2::xml_find_all(res, ".//a"))
 })

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -1,6 +1,6 @@
 
 
-test_that("paths in instructor view that are not HTML get diverted", {
+test_that("paths in instructor view that are nested or not HTML get diverted", {
   html_test <- xml2::read_html(commonmark::markdown_html(c(
     "[a](index.html)",
     "[b](./index.html)",
@@ -11,7 +11,7 @@ test_that("paths in instructor view that are not HTML get diverted", {
     "[g](files/confirmation.html)"
   )))
   res <- xml2::read_html(use_instructor(html_test))
-  # there are fo
+  # All but two refs are transformed according to our rules
   refs <- xml2::xml_text(xml2::xml_find_all(res, ".//@href"))
   expect_equal(startsWith(refs, "../"),
     c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE))

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -2,21 +2,23 @@
 
 test_that("paths in instructor view that are nested or not HTML get diverted", {
   html_test <- xml2::read_html(commonmark::markdown_html(c(
+    "<a id='what-the'></a><h2>h</h2>\n",
     "[a](index.html)",
     "[b](./index.html)",
     "[c](fig/thing.png)",
     "[d](./fig/thang.jpg)",
     "[e](data/thing.csv)",
     "[f](files/papers/thing.pdf)",
-    "[g](files/confirmation.html)"
+    "[g](files/confirmation.html)",
+    "[h](#what-the)"
   )))
   res <- xml2::read_html(use_instructor(html_test))
   # All but two refs are transformed according to our rules
   refs <- xml2::xml_text(xml2::xml_find_all(res, ".//@href"))
   expect_equal(startsWith(refs, "../"),
-    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE))
-  expect_snapshot(xml2::xml_find_all(html_test, ".//a"))
-  expect_snapshot(xml2::xml_find_all(res, ".//a"))
+    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE))
+  expect_snapshot(xml2::xml_find_all(html_test, ".//a[@href]"))
+  expect_snapshot(xml2::xml_find_all(res, ".//a[@href]"))
 })
 
 

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -5,18 +5,20 @@ test_that("paths in instructor view that are nested or not HTML get diverted", {
     "<a id='what-the'></a><h2>h</h2>\n",
     "[a](index.html)",
     "[b](./index.html)",
-    "[c](fig/thing.png)",
-    "[d](./fig/thang.jpg)",
-    "[e](data/thing.csv)",
-    "[f](files/papers/thing.pdf)",
-    "[g](files/confirmation.html)",
-    "[h](#what-the)"
+    "[c](fig/thing.png)",           # asset
+    "[d](./fig/thang.jpg)",         # asset
+    "[e](data/thing.csv)",          # asset
+    "[f](files/papers/thing.pdf)",  # asset
+    "[g](files/confirmation.html)", # asset
+    "[h](#what-the)",
+    "[i](other-page.html#section)",
+    "[j](other-page)"
   )))
   res <- xml2::read_html(use_instructor(html_test))
-  # All but two refs are transformed according to our rules
+  # refs are transformed according to our rules
   refs <- xml2::xml_text(xml2::xml_find_all(res, ".//@href"))
   expect_equal(startsWith(refs, "../"),
-    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE))
+    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE))
   expect_snapshot(xml2::xml_find_all(html_test, ".//a[@href]"))
   expect_snapshot(xml2::xml_find_all(res, ".//a[@href]"))
 })


### PR DESCRIPTION
This updates the processing of instructor view asset links to correctly resolve
to the respective assets that are in the root directory. 


This will fix #404
