### PR TITLE
Provision references.md to fix Glossary 404; Maintainer QOL improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.9
+Version: 0.11.10
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,24 @@
-# sandpaper 0.11.9 (in development)
+# sandpaper 0.11.10 (in development)
 
-BUG FIX
--------
+## BUG FIX
+
+* New lessons will now provision `learners/resources.md`, which will allow the
+  glossary link to work (reported: @elichad, #404 and 
+  @ManonMarchand,
+  https://github.com/carpentries/workbench-template-md/issues/20; 
+  fixed: @zkamvar, #410)
+- default CONTRIBUTING file is better suited to The Workbench and no longer
+  references the now-defunct lesson-example repository (reported and fixed:
+  @jcolomb, #407)
+
+# sandpaper 0.11.9 (2023-03-14)
+
+## BUG FIX
 
 * Links to assets in instructor view no longer render a 404. (reported:
-  @brownsarahm, #404; fixed: @zkamvar, #408)
+  @brownsarahm, #404; fixed: @zkamvar, #409)
 
-CONTINUOUS INTEGRATION
-----------------------
+## CONTINUOUS INTEGRATION
 
 * Lessons with files that have spaces in their names (e.g as a learning tool)
   no longer fail to comment on pull request previews (reported: @zkamvar, #399;

--- a/R/create_lesson.R
+++ b/R/create_lesson.R
@@ -46,6 +46,8 @@ create_lesson <- function(path, name = fs::path_file(path), rmd = TRUE, rstudio 
   copy_template("links", path, "links.md")
   copy_template("placeholder", fs::path(path, "instructors"), "instructor-notes.md")
   copy_template("placeholder", fs::path(path, "profiles"), "learner-profiles.md")
+  copy_template("placeholder", fs::path(path, "learners"), "reference.md",
+    values = c(title = "Glossary"))
 
   cli::cli_status_update("{cli::symbol$arrow_right} Generating {.file config.yaml} ...")
   account <- tryCatch(gh::gh_whoami()$login, error = function(e) "carpentries")
@@ -53,6 +55,7 @@ create_lesson <- function(path, name = fs::path_file(path), rmd = TRUE, rstudio 
     values = list(
       title      = if (is.null(match.call()$name)) "Lesson Title" else siQuote(name),
       carpentry  = "incubator",
+      created    = as.character(Sys.Date()),
       life_cycle = "pre-alpha",
       license    = "CC-BY 4.0",
       source     = glue::glue("https://github.com/{account}/{basename(path)}"),

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -22,6 +22,11 @@
 create_test_lesson <- function() {
   noise <- interactive() || Sys.getenv("CI") == "true"
   if (noise) {
+    t1 <- Sys.time()
+    on.exit({
+      ts <- format(Sys.time() - t1)
+      cli::cli_alert_info("Lesson bootstrapped in {ts}")
+    }, add = TRUE)
     cli::cli_status("{cli::symbol$arrow_right} Bootstrapping example lesson")
   }
   # We explicitly need the package cache for tests
@@ -36,10 +41,11 @@ create_test_lesson <- function() {
   }
   suppressMessages({
     withr::with_envvar(list(RENV_CONFIG_CACHE_SYMLINKS = FALSE), {
-      create_lesson(repo, open = FALSE)
+      renv_output <- capture.output(create_lesson(repo, open = FALSE))
     })
   })
   options(sandpaper.test_fixture = repo)
+  options(sandpaper.test_fixture_output = renv_output)
   generate_restore_fixture(repo)
 }
 
@@ -100,6 +106,14 @@ generate_restore_fixture <- function(repo) {
 #' @keywords internal
 setup_local_remote <- function(repo, remote = tempfile(), name = "sandpaper-local", verbose = FALSE) {
   tf <- getOption("sandpaper.test_fixture")
+  noise <- interactive() || Sys.getenv("CI") == "true"
+  if (noise) {
+    t1 <- Sys.time()
+    on.exit({
+      ts <- format(Sys.time() - t1)
+      cli::cli_alert_info("Remote set up in {ts}")
+    }, add = TRUE)
+  }
   stopifnot("This should only be run in a test context" = !is.null(tf))
   if (!fs::dir_exists(remote)) {
     fs::dir_create(remote)

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -41,7 +41,7 @@ create_test_lesson <- function() {
   }
   suppressMessages({
     withr::with_envvar(list(RENV_CONFIG_CACHE_SYMLINKS = FALSE), {
-      renv_output <- capture.output(create_lesson(repo, open = FALSE))
+      renv_output <- utils::capture.output(create_lesson(repo, open = FALSE))
     })
   })
   options(sandpaper.test_fixture = repo)

--- a/R/utils-sidebar.R
+++ b/R/utils-sidebar.R
@@ -18,12 +18,13 @@ page_location <- function(i, abs_md, er) {
 #'
 #' @param files a vector of markdown file names
 #' @param type one of "learners" (default) or "instructors". If it is learners,
-#'   the setup page will be excluded since it is included in the index. For 
+#'   the setup page will be excluded since it is included in the index. For
 #'   "instructors", the instructor notes are included and the learner profiles
 #'   are included.
-#' @return a list with character vectors of HTML list elements. 
+#' @return a list with character vectors of HTML list elements.
 #' @keywords internal
 create_resources_dropdown <- function(files, type = "learners") {
+  files <- files[!grepl("reference.md", fs::path_file(files))]
   if (type == "learners") {
     files <- files[!grepl("setup[.]R?md", fs::path_file(files))]
   }
@@ -53,10 +54,10 @@ create_resources_dropdown <- function(files, type = "learners") {
 }
 
 #' Create a single item that appears in the sidebar
-#' 
+#'
 #' Varnish uses a sidebar for navigation across and within an episode. This
-#' funciton will create a sidebar item for a single episode, providing a 
-#' dropdown menu of the sections within the episode if it is labeled as the 
+#' funciton will create a sidebar item for a single episode, providing a
+#' dropdown menu of the sections within the episode if it is labeled as the
 #' current episode.
 #'
 #' @param nodes html generated from [render_html()] or parsed from xml2
@@ -73,7 +74,7 @@ create_sidebar_item <- function(nodes, name, position) {
     headings = if (current) create_sidebar_headings(nodes) else NULL,
     current = current
   )
-  whisker::whisker.render(readLines(template_sidebar_item()), 
+  whisker::whisker.render(readLines(template_sidebar_item()),
     data = sidebar_data)
 }
 
@@ -105,9 +106,9 @@ create_sidebar_headings <- function(nodes) {
 
 #' Create the sidebar for varnish
 #'
-#' Varnish uses a sidebar for navigation across and within an episode. Each 
+#' Varnish uses a sidebar for navigation across and within an episode. Each
 #' episode's sidebar is different because there needs to be a clear indicator
-#' which episode is the current one within the sidebar. 
+#' which episode is the current one within the sidebar.
 #'
 #' This function creates that sidebar.
 #'
@@ -121,8 +122,8 @@ create_sidebar <- function(chapters, name = "", html = "<a href='https://carpent
   for (i in seq(chapters)) {
     position <- if (name == chapters[i]) "current" else i
     info <- get_navbar_info(chapters[i])
-    page_link <- paste0("<a href='", info$href, "'>", 
-      i - 1, ". ", parse_title(info$pagetitle), 
+    page_link <- paste0("<a href='", info$href, "'>",
+      i - 1, ". ", parse_title(info$pagetitle),
       "</a>")
     res[i] <- create_sidebar_item(html, page_link, position)
   }

--- a/R/utils-sidebar.R
+++ b/R/utils-sidebar.R
@@ -24,12 +24,12 @@ page_location <- function(i, abs_md, er) {
 #' @return a list with character vectors of HTML list elements.
 #' @keywords internal
 create_resources_dropdown <- function(files, type = "learners") {
-  files <- files[!grepl("reference.md", fs::path_file(files))]
+  files <- files[!grepl("reference[.]R?md$", fs::path_file(files))]
   if (type == "learners") {
-    files <- files[!grepl("setup[.]R?md", fs::path_file(files))]
+    files <- files[!grepl("setup[.]R?md$", fs::path_file(files))]
   }
   if (type == "instructors") {
-    files <- files[!grepl("instructor-notes.md", fs::path_file(files))]
+    files <- files[!grepl("instructor-notes[.]R?md$", fs::path_file(files))]
   }
   out <- list(extras = NULL, resources = NULL)
   # NOTE: this creates a vector of length two: the first one has links with the

--- a/inst/templates/placeholder-template.txt
+++ b/inst/templates/placeholder-template.txt
@@ -2,4 +2,8 @@
 title: FIXME
 ---
 
-This is a placeholder file. Please add content here. 
+{{#title}}
+## {{title}}
+
+{{/title}}
+This is a placeholder file. Please add content here.

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -16,11 +16,11 @@ test_that("Lessons built for the first time are noisy", {
   htmls <- read_all_html(sitepath)
   expect_setequal(names(htmls$learner),
     c("introduction", "index", "LICENSE", "CODE_OF_CONDUCT", "profiles",
-      "instructor-notes", "key-points", "aio", "images")
+      "instructor-notes", "key-points", "aio", "images", "reference")
   )
   expect_setequal(names(htmls$instructor),
     c("introduction", "index", "LICENSE", "CODE_OF_CONDUCT", "profiles",
-      "instructor-notes", "key-points", "aio", "images")
+      "instructor-notes", "key-points", "aio", "images", "reference")
   )
 
 })

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -10,9 +10,11 @@
 test_that("lessons can be created in empty directories", {
 
   expect_false(fs::dir_exists(tmp))
-  suppressMessages({expect_message({
+  suppressMessages({capture.output({
     res <- create_lesson(tmp, name = "BRAND NEW LESSON", rstudio = TRUE, open = TRUE)
-  }, "Setting active project to")})
+  }) %>%
+    expect_message("Lesson successfully created")
+  })
   tmp <- normalizePath(tmp)
   expect_false(wd == fs::path(normalizePath(getwd())))
   expect_equal(normalizePath(getwd()), tmp)

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -37,9 +37,9 @@ test_that("check_lesson() passes muster on new lessons", {
 test_that("All template files exist", {
   expect_true(fs::dir_exists(tmp))
   expect_equal(
-    politely_get_yaml(fs::path(tmp, "index.md"))[[2]], 
+    politely_get_yaml(fs::path(tmp, "index.md"))[[2]],
     "site: sandpaper::sandpaper_site"
-  ) 
+  )
   expect_true(fs::dir_exists(fs::path(tmp, "site")))
   expect_true(fs::dir_exists(fs::path(tmp, "episodes")))
   expect_true(fs::dir_exists(fs::path(tmp, "episodes", "data")))
@@ -48,8 +48,12 @@ test_that("All template files exist", {
   expect_true(fs::dir_exists(fs::path(tmp, "instructors")))
   expect_true(fs::dir_exists(fs::path(tmp, "learners")))
   expect_true(fs::dir_exists(fs::path(tmp, "profiles")))
+  expect_true(fs::file_exists(fs::path(tmp, "learners", "setup.md")))
+  expect_true(fs::file_exists(fs::path(tmp, "learners", "reference.md")))
+  expect_true(any(grepl("Glossary", readLines(fs::path(tmp, "learners", "reference.md")))))
+  expect_true(fs::file_exists(fs::path(tmp, "instructors", "instructor-notes.md")))
   expect_true(fs::file_exists(fs::path(tmp, "README.md")))
-  expect_match(readLines(fs::path(tmp, "README.md"))[1], "BRAND NEW LESSON", fixed = TRUE) 
+  expect_match(readLines(fs::path(tmp, "README.md"))[1], "BRAND NEW LESSON", fixed = TRUE)
   expect_true(fs::file_exists(fs::path(tmp, "site", "README.md")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "DESCRIPTION")))
   expect_true(fs::file_exists(fs::path(tmp, "site", "_pkgdown.yaml")))
@@ -61,16 +65,16 @@ test_that("All template files exist", {
 
 test_that("Templated files are correct", {
   expect_setequal(
-    readLines(fs::path(tmp, ".gitignore")), 
+    readLines(fs::path(tmp, ".gitignore")),
     readLines(template_gitignore())
   )
-  expected <- copy_template("episode", 
+  expected <- copy_template("episode",
     values = list(title = siQuote("introduction"), md = FALSE))
   expect_setequal(
-    readLines(fs::path(tmp, "episodes", "introduction.Rmd")), 
+    readLines(fs::path(tmp, "episodes", "introduction.Rmd")),
     strsplit(expected, "\n")[[1]]
   )
-  
+
 })
 
 test_that("Lesson configuration is correctly provisioned", {
@@ -121,8 +125,8 @@ cli::test_that_cli("Destruction of the .gitignore file renders the lesson incorr
 
   if (fs::file_exists(gi <- fs::path(tmp, ".gitignore"))) fs::file_delete(gi)
   expect_snapshot({
-    expect_error( 
-      check_lesson(tmp), 
+    expect_error(
+      check_lesson(tmp),
       "There were errors with the lesson structure"
     )
   })

--- a/tests/testthat/test-get_dropdown.R
+++ b/tests/testthat/test-get_dropdown.R
@@ -4,7 +4,7 @@ create_episode("outroduction", path = res)
 outro <- fs::path(res, "episodes", "outroduction.Rmd")
 fs::file_move(outro, fs::path_ext_set(outro, "md"))
 
-# NOTE: make sure that filenames do not clash at the moment... they will. 
+# NOTE: make sure that filenames do not clash at the moment... they will.
 lt <- fs::file_create(fs::path(tmp, "learners", c("learner-test.md")))
 it <- fs::file_create(fs::path(tmp, "instructors", c("test1.md", "test2.md")))
 pt <- fs::file_create(fs::path(tmp, "profiles", c("profileA.md", "profileB.md")))
@@ -13,8 +13,8 @@ reset_episodes(res)
 }
 
 cli::test_that_cli("get_dropdown works as expected with messages", {
-  
-  expect_error(get_dropdown(res), "folder") # folder missing with no default 
+
+  expect_error(get_dropdown(res), "folder") # folder missing with no default
   expect_snapshot(s <- get_dropdown(res, "episodes"))
   expect_equal(s, eps)
 }, configs = "plain")
@@ -84,7 +84,7 @@ test_that("get_profiles() returns the contents of the profiles directory", {
 
   expected <- basename(as.character(fs::dir_ls(fs::path(tmp, "profiles"))))
   expect_equal(c("learner-profiles.md", basename(pt)), expected)
-  
+
   expect_silent(p <- get_profiles(res))
   expect_equal(p, expected)
   set_profiles(res, rev(p), write = TRUE)

--- a/tests/testthat/test-get_dropdown.R
+++ b/tests/testthat/test-get_dropdown.R
@@ -51,7 +51,7 @@ test_that("get_episodes() works in the right order", {
 test_that("get_learners() returns contents of the learners directory", {
 
   expected <- basename(as.character(fs::dir_ls(fs::path(tmp, "learners"))))
-  expect_setequal(expected, c("setup.md", basename(lt)))
+  expect_setequal(expected, c("setup.md", "reference.md", basename(lt)))
 
   expect_silent(l <- get_learners(res))
   expect_equal(l, expected)


### PR DESCRIPTION
This will fix #401 by explicitly provisioning a `learners/references.md` file in new lessons.

This was originally overlooked because we were working from the assumption that lessons would transition from the styles repository. 

This PR will also improve maintainer QOL by suppressing the output of {renv} during the build process and reports how long it takes to provision the test fixture. 

Note that this must be propogated to the workbench templates. 

