### PR TITLE
Update cache reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.10
+Version: 0.11.11
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -14,7 +14,7 @@ Authors@R: c(
     person(given = "Julien",
            family = "Colomb",
            role = c("ctb"),
-           comment = c(ORCID = "0000-0002-3127-5520")),       
+           comment = c(ORCID = "0000-0002-3127-5520")),
     person(given = "Toby",
            family = "Hodges",
            role = c("ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,17 @@
-# sandpaper 0.11.10 (in development)
+# sandpaper 0.11.11 (2023-03-17)
+
+## BUG FIX
+
+* `update_cache()` will now work with {renv} version 0.17.1, which lost a
+  print method for the `renv_updates` class (reported: @zkamvar, #415; 
+  fixed: @zkamvar, #416 and 
+  https://github.com/zkamvar/vise/commit/ee4798701a958ee48429980eb970266885f8265b
+
+# MISC
+
+* @jcolomb has been added as a contributor in the DESCRIPTION.
+
+# sandpaper 0.11.10 (2023-03-16)
 
 ## BUG FIX
 

--- a/R/manage_deps.R
+++ b/R/manage_deps.R
@@ -114,20 +114,24 @@ update_cache <- function(path = ".", profile = "lesson-requirements", prompt = i
   Sys.setenv("RENV_PROFILE" = profile)
   renv::load(project = path)
   lib <- renv::paths$library(project = path)
-  has_cli <- requireNamespace("cli", quietly = TRUE)
   if (prompt) {
     updates <- renv::update(library = lib, check = TRUE, prompt = TRUE)
     if (isTRUE(updates)) {
       return(invisible())
     }
-    wanna_update <- "Do you want to update the following packages?"
-    if (has_cli) cli::cli_alert(wanna_update) else message(wanna_update)
-    ud <- utils::capture.output(print(updates))
-    message(paste(ud, collapse = "\n"))
+    if (packageVersion("renv") < "0.17.1") {
+      wanna_update <- "Do you want to update the following packages?"
+      cli::cli_alert(wanna_update)
+      ud <- utils::capture.output(print(updates))
+      message(paste(ud, collapse = "\n"))
+    } else {
+      wanna_update <- "Do you want to update these packages?"
+      cli::cli_alert(wanna_update)
+    }
     res <- utils::menu(c("Yes", "No"))
     if (res != 1) {
       no <- "Not updating at this time"
-      if (has_cli) cli::cli_alert_info(no) else message(no)
+      cli::cli_alert_info(no)
       return(invisible())
     }
   }


### PR DESCRIPTION
renv 0.17.1 has changed the reporting method for `renv::update()`, so I had to add a conditional to reflect that.

This fixes #415 

