### PR TITLE
Fix Templates; update dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.13
+Version: 0.11.14
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -27,7 +27,7 @@ Description: We provide tools to build a Carpentries-themed lesson repository
 License: MIT + file LICENSE
 Imports:
     pkgdown (>= 1.6.0),
-    pegboard (>= 0.2.3),
+    pegboard (>= 0.5.1),
     cli (>= 3.4.0),
     commonmark,
     fs (>= 1.5.0),
@@ -55,23 +55,23 @@ Suggests:
     brio,
     xml2,
     xslt,
-    covr,
     withr,
     jsonlite,
     sessioninfo,
-    varnish (>= 0.2.1),
-    mockr
+    mockr,
+    varnish (>= 0.2.1)
 Additional_repositories: https://carpentries.r-universe.dev/
 Remotes:
   ropensci/tinkr,
   carpentries/pegboard,
   carpentries/varnish
-SystemRequirements: pandoc (>= 1.11.4) - http://pandoc.org
+SystemRequirements: pandoc (>= 2.11.4) - https://pandoc.org
 Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Config/Needs/check: rstudio/renv
+Config/Needs/coverage: covr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 URL: https://carpentries.github.io/sandpaper/, https://github.com/carpentries/sandpaper/, https://carpentries.github.io/workbench/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Imports:
     tools
 Suggests:
     testthat (>= 3.0.0),
+    covr,
     markdown,
     brio,
     xml2,
@@ -71,7 +72,6 @@ LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Config/Needs/check: rstudio/renv
-Config/Needs/coverage: covr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 URL: https://carpentries.github.io/sandpaper/, https://github.com/carpentries/sandpaper/, https://carpentries.github.io/workbench/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,19 @@
+# sandpaper 0.11.14 (2023-04-04)
+
+## DEPENDENCIES
+
+* The minimum version of {pegboard} has been set to 0.5.1
+
+## TEMPLATES
+
+* The README, LICENSE, CONTRIBUTING, and SETUP templates have been fixed to work
+  with {pegboard} version 0.5.1
+* The LICENSE and CONTRIBUTING templates now refer to The Carpentries as a
+  whole and provides correct links to community forums. 
+
 # sandpaper 0.11.13 (2023-03-25)
 
-WORKAROUND
-----------
+## WORKAROUND
 
 * Fix an issue for {renv} version 0.17.2 where it was unable to provision
   packages that were being used in the parent environment. This was a problem
@@ -12,8 +24,7 @@ WORKAROUND
 
 # sandpaper 0.11.12 (2023-03-22)
 
-CONTINUOUS INTEGRATION
-----------------------
+## CONTINUOUS INTEGRATION
 
 * workflow files now have explicit permissions to comment on pull requests or
   create new branches when called. This fixes an issue where new lessons would
@@ -22,8 +33,7 @@ CONTINUOUS INTEGRATION
 * the `create-pull-request` action is now coming from a fork in The Carpentries
   organisation for security. 
 
-MISC
-----
+## MISC
 
 * A typo has been fixed in the package cache vignette
 - The CONTRIBUTING boilerplate has been updated to fix formatting issues

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -41,7 +41,9 @@ create_test_lesson <- function() {
   }
   suppressMessages({
     withr::with_envvar(list(RENV_CONFIG_CACHE_SYMLINKS = FALSE), {
-      renv_output <- utils::capture.output(create_lesson(repo, open = FALSE))
+      renv_output <- utils::capture.output(
+        create_lesson(repo, open = FALSE)
+      )
     })
   })
   options(sandpaper.test_fixture = repo)

--- a/R/utils.R
+++ b/R/utils.R
@@ -99,7 +99,7 @@ isTRUE  <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && x
 
 create_lesson_readme <- function(name, path) {
 
-  writeLines(glue::glue("# {name}
+  writeLines(glue::glue("## {name}
 
       This is the lesson repository for {name}
   "), con = fs::path(path, "README.md"))

--- a/inst/templates/contributing-template.txt
+++ b/inst/templates/contributing-template.txt
@@ -1,134 +1,120 @@
-# Contributing
+## Contributing
 
-[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
-and we welcome contributions of all kinds:
-new lessons,
-fixes to existing material,
-bug reports,
-and reviews of proposed changes are all welcome.
+[The Carpentries][cp-site] ([Software Carpentry][swc-site], [Data
+Carpentry][dc-site], and [Library Carpentry][lc-site]) are open source
+projects, and we welcome contributions of all kinds: new lessons, fixes to
+existing material, bug reports, and reviews of proposed changes are all
+welcome.
 
-## Contributor Agreement
+### Contributor Agreement
 
-By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
-In exchange,
-we will address your issues and/or assess your change proposal as promptly as we can,
-and help you become a member of our community.
-Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+By contributing, you agree that we may redistribute your work under [our
+license](LICENSE.md). In exchange, we will address your issues and/or assess
+your change proposal as promptly as we can, and help you become a member of our
+community. Everyone involved in [The Carpentries][cp-site] agrees to abide by
+our [code of conduct](CODE_OF_CONDUCT.md).
 
-## How to Contribute
+### How to Contribute
 
-The easiest way to get started is to file an issue
-to tell us about a spelling mistake,
-some awkward wording,
-or a factual error.
-This is a good way to introduce yourself
-and to meet some of our community members.
+The easiest way to get started is to file an issue to tell us about a spelling
+mistake, some awkward wording, or a factual error. This is a good way to
+introduce yourself and to meet some of our community members.
 
-1.  If you do not have a [GitHub][github] account,
-    you can [send us comments by email][contact].
-    However,
-    we will be able to respond more quickly if you use one of the other methods described below.
+1. If you do not have a [GitHub][github] account, you can [send us comments by
+   email][contact]. However, we will be able to respond more quickly if you use
+   one of the other methods described below.
 
-2.  If you have a [GitHub][github] account,
-    or are willing to [create one][github-join],
-    but do not know how to use Git,
-    you can report problems or suggest improvements by [creating an issue][issues].
-    This allows us to assign the item to someone
-    and to respond to it in a threaded discussion.
+2. If you have a [GitHub][github] account, or are willing to [create
+   one][github-join], but do not know how to use Git, you can report problems
+   or suggest improvements by [creating an issue][issues]. This allows us to
+   assign the item to someone and to respond to it in a threaded discussion.
 
-3.  If you are comfortable with Git,
-    and would like to add or change material,
-    you can submit a pull request (PR).
-    Instructions for doing this are [included below](#using-github).
-    
-Note: if you want to build the website locally, please refer to [The Workbench documentation][template-doc].    
+3. If you are comfortable with Git, and would like to add or change material,
+   you can submit a pull request (PR). Instructions for doing this are
+   [included below](#using-github).
 
-## Where to Contribute
+Note: if you want to build the website locally, please refer to [The Workbench
+documentation][template-doc].
 
-1.  If you wish to change this lesson,
-    add issues and PR here.   
-2.  If you wish to change the template used for workshop websites,
-    please refer to [The Workbench documentation][template-doc].
+### Where to Contribute
+
+1. If you wish to change this lesson, add issues and PR here.
+2. If you wish to change the template used for workshop websites, please refer
+   to [The Workbench documentation][template-doc].
 
 
-## What to Contribute
+### What to Contribute
 
-There are many ways to contribute,
-from writing new exercises and improving existing ones
-to updating or filling in the documentation
-and submitting [bug reports][issues]
-about things that don't work, aren't clear, or are missing.
-If you are looking for ideas,
-please see [the list of issues for this repository][issues],
-or the issues for [Data Carpentry][dc-issues]
-and [Software Carpentry][swc-issues] projects.
+There are many ways to contribute, from writing new exercises and improving
+existing ones to updating or filling in the documentation and submitting [bug
+reports][issues] about things that don't work, aren't clear, or are missing. If
+you are looking for ideas, please see [the list of issues for this
+repository][issues], or the issues for [Data Carpentry][dc-issues] and
+[Software Carpentry][swc-issues] projects.
 
-Comments on issues and reviews of pull requests are just as welcome:
-we are smarter together than we are on our own.
-**Reviews from novices and newcomers are particularly valuable**:
-it's easy for people who have been using these lessons for a while
-to forget how impenetrable some of this material can be,
-so fresh eyes are always welcome.
+Comments on issues and reviews of pull requests are just as welcome: we are
+smarter together than we are on our own. **Reviews from novices and newcomers
+are particularly valuable**: it's easy for people who have been using these
+lessons for a while to forget how impenetrable some of this material can be, so
+fresh eyes are always welcome.
 
-## What *Not* to Contribute
+### What *Not* to Contribute
 
-Our lessons already contain more material than we can cover in a typical workshop,
-so we are usually *not* looking for more concepts or tools to add to them.
-As a rule,
-if you want to introduce a new idea,
-you must (a) estimate how long it will take to teach
-and (b) explain what you would take out to make room for it.
-The first encourages contributors to be honest about requirements;
-the second, to think hard about priorities.
+Our lessons already contain more material than we can cover in a typical
+workshop, so we are usually *not* looking for more concepts or tools to add to
+them. As a rule, if you want to introduce a new idea, you must (a) estimate how
+long it will take to teach and (b) explain what you would take out to make room
+for it. The first encourages contributors to be honest about requirements; the
+second, to think hard about priorities.
 
-We are also not looking for exercises or other material that only run on one platform.
-Our workshops typically contain a mixture of Windows, macOS, and Linux users;
-in order to be usable,
-our lessons must run equally well on all three.
+We are also not looking for exercises or other material that only run on one
+platform. Our workshops typically contain a mixture of Windows, macOS, and
+Linux users; in order to be usable, our lessons must run equally well on all
+three.
 
-## Using GitHub
+### Using GitHub
 
-If you choose to contribute via GitHub,
-you may want to look at
-[How to Contribute to an Open Source Project on GitHub][how-contribute].
-In brief, we use [GitHub flow][github-flow] to manage changes:
+If you choose to contribute via GitHub, you may want to look at [How to
+Contribute to an Open Source Project on GitHub][how-contribute]. In brief, we
+use [GitHub flow][github-flow] to manage changes:
 
-1.  Create a new branch in your desktop copy of this repository for each significant change.
-2.  Commit the change in that branch.
-3.  Push that branch to your fork of this repository on GitHub.
-4.  Submit a pull request from that branch to the [upstream repository][repo].
-5.  If you receive feedback,
-make changes on your desktop and push to your branch on GitHub:
-the pull request will update automatically.
+1. Create a new branch in your desktop copy of this repository for each
+   significant change.
+2. Commit the change in that branch.
+3. Push that branch to your fork of this repository on GitHub.
+4. Submit a pull request from that branch to the [upstream repository][repo].
+5. If you receive feedback, make changes on your desktop and push to your
+   branch on GitHub: the pull request will update automatically.
 
 NB: The published copy of the lesson is usually in the `main` branch.
 
-Each lesson has two maintainers who review issues and pull requests
-or encourage others to do so.
-The maintainers are community volunteers,
-and have final say over what gets merged into the lesson.
+Each lesson has two maintainers who review issues and pull requests or
+encourage others to do so. The maintainers are community volunteers, and have
+final say over what gets merged into the lesson.
 
-## Other Resources
+### Other Resources
 
-General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-happens on the [discussion mailing list][discuss-list],
-which everyone is welcome to join.
-You can also [reach us by email][contact].
+The Carpentries is a global organisation with volunteers and learners all over
+the world. We share values of inclusivity and a passion for sharing knowledge,
+teaching and learning. There are several ways to connect with The Carpentries
+community listed at <https://carpentries.org/connect/> including via social
+media, slack, newsletters, and email lists. You can also [reach us by
+email][contact].
 
-[contact]: mailto:admin@software-carpentry.org
+[contact]: mailto:team@carpentries.org
+[cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[dc-lessons]: http://datacarpentry.org/lessons/
-[dc-site]: http://datacarpentry.org/
-[discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
-[github]: http://github.com
+[dc-lessons]: https://datacarpentry.org/lessons/
+[dc-site]: https://datacarpentry.org/
+[discuss-list]: https://lists.software-carpentry.org/listinfo/discuss
+[github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/shell-novice/issues/
+[issues]: https://carpentries.org/help-wanted-issues/
 [repo]: https://github.com/swcarpentry/shell-novice/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
-[swc-lessons]: http://software-carpentry.org/lessons/
-[swc-site]: http://software-carpentry.org/
+[swc-lessons]: https://software-carpentry.org/lessons/
+[swc-site]: https://software-carpentry.org/
+[lc-site]: https://librarycarpentry.org/
 [template-doc]: https://carpentries.github.io/workbench/

--- a/inst/templates/contributing-template.txt
+++ b/inst/templates/contributing-template.txt
@@ -47,10 +47,10 @@ documentation][template-doc].
 
 There are many ways to contribute, from writing new exercises and improving
 existing ones to updating or filling in the documentation and submitting [bug
-reports][issues] about things that do not work, are not clear, or are missing. If
-you are looking for ideas, please see [the list of issues for this
-repository][issues], or the issues for [Data Carpentry][dc-issues], [Library Carpentry][lc-issues], and
-[Software Carpentry][swc-issues] projects.
+reports][issues] about things that do not work, are not clear, or are missing.
+If you are looking for ideas, please see [the list of issues for this
+repository][repo], or the issues for [Data Carpentry][dc-issues], [Library
+Carpentry][lc-issues], and [Software Carpentry][swc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome: we are
 smarter together than we are on our own. **Reviews from novices and newcomers
@@ -101,6 +101,7 @@ community listed at <https://carpentries.org/connect/> including via social
 media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
+[repo]: https://example.com/FIXME
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -113,7 +114,6 @@ email][contact].
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
 [lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
-[repo]: https://github.com/swcarpentry/shell-novice/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: https://software-carpentry.org/lessons/
 [swc-site]: https://software-carpentry.org/

--- a/inst/templates/contributing-template.txt
+++ b/inst/templates/contributing-template.txt
@@ -38,7 +38,7 @@ documentation][template-doc].
 
 ### Where to Contribute
 
-1. If you wish to change this lesson, add issues and PR here.
+1. If you wish to change this lesson, add issues and pull requests here.
 2. If you wish to change the template used for workshop websites, please refer
    to [The Workbench documentation][template-doc].
 
@@ -47,9 +47,9 @@ documentation][template-doc].
 
 There are many ways to contribute, from writing new exercises and improving
 existing ones to updating or filling in the documentation and submitting [bug
-reports][issues] about things that don't work, aren't clear, or are missing. If
+reports][issues] about things that do not work, are not clear, or are missing. If
 you are looking for ideas, please see [the list of issues for this
-repository][issues], or the issues for [Data Carpentry][dc-issues] and
+repository][issues], or the issues for [Data Carpentry][dc-issues], [Library Carpentry][lc-issues], and
 [Software Carpentry][swc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome: we are
@@ -88,7 +88,7 @@ use [GitHub flow][github-flow] to manage changes:
 
 NB: The published copy of the lesson is usually in the `main` branch.
 
-Each lesson has two maintainers who review issues and pull requests or
+Each lesson has a team of maintainers who review issues and pull requests or
 encourage others to do so. The maintainers are community volunteers, and have
 final say over what gets merged into the lesson.
 
@@ -112,6 +112,7 @@ email][contact].
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
+[lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
 [repo]: https://github.com/swcarpentry/shell-novice/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: https://software-carpentry.org/lessons/

--- a/inst/templates/license-template.txt
+++ b/inst/templates/license-template.txt
@@ -4,79 +4,76 @@ title: "Licenses"
 
 ## Instructional Material
 
-All Software Carpentry, Data Carpentry, and Library Carpentry instructional material is
-made available under the [Creative Commons Attribution
-license][cc-by-human]. The following is a human-readable summary of
+All Carpentries (Software Carpentry, Data Carpentry, and Library Carpentry)
+instructional material is made available under the [Creative Commons
+Attribution license][cc-by-human]. The following is a human-readable summary of
 (and not a substitute for) the [full legal text of the CC BY 4.0
 license][cc-by-legal].
 
 You are free:
 
-* to **Share**---copy and redistribute the material in any medium or format
-* to **Adapt**---remix, transform, and build upon the material
+- to **Share**---copy and redistribute the material in any medium or format
+- to **Adapt**---remix, transform, and build upon the material
 
 for any purpose, even commercially.
 
-The licensor cannot revoke these freedoms as long as you follow the
-license terms.
+The licensor cannot revoke these freedoms as long as you follow the license
+terms.
 
 Under the following terms:
 
-* **Attribution**---You must give appropriate credit (mentioning that
-  your work is derived from work that is Copyright © Software
-  Carpentry and, where practical, linking to
-  http://software-carpentry.org/), provide a [link to the
-  license][cc-by-human], and indicate if changes were made. You may do
-  so in any reasonable manner, but not in any way that suggests the
-  licensor endorses you or your use.
+- **Attribution**---You must give appropriate credit (mentioning that your work
+  is derived from work that is Copyright (c) The Carpentries and, where
+  practical, linking to <https://carpentries.org/>), provide a [link to the
+  license][cc-by-human], and indicate if changes were made. You may do so in
+  any reasonable manner, but not in any way that suggests the licensor endorses
+  you or your use.
 
-**No additional restrictions**---You may not apply legal terms or
-technological measures that legally restrict others from doing
-anything the license permits.  With the understanding that:
+- **No additional restrictions**---You may not apply legal terms or
+  technological measures that legally restrict others from doing anything the
+  license permits.  With the understanding that:
 
 Notices:
 
-* You do not have to comply with the license for elements of the
-  material in the public domain or where your use is permitted by an
-  applicable exception or limitation.
-* No warranties are given. The license may not give you all of the
-  permissions necessary for your intended use. For example, other
-  rights such as publicity, privacy, or moral rights may limit how you
-  use the material.
+* You do not have to comply with the license for elements of the material in
+  the public domain or where your use is permitted by an applicable exception
+  or limitation.
+* No warranties are given. The license may not give you all of the permissions
+  necessary for your intended use. For example, other rights such as publicity,
+  privacy, or moral rights may limit how you use the material.
 
 ## Software
 
-Except where otherwise noted, the example programs and other software
-provided by Software Carpentry and Data Carpentry are made available under the
-[OSI][osi]-approved
-[MIT license][mit-license].
+Except where otherwise noted, the example programs and other software provided
+by The Carpentries are made available under the [OSI][osi]-approved [MIT
+license][mit-license].
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ## Trademark
 
-"Software Carpentry" and "Data Carpentry" and their respective logos
-are registered trademarks of [Community Initiatives][ci].
+"The Carpentries", "Software Carpentry", "Data Carpentry", and "Library
+Carpentry" and their respective logos are registered trademarks of [Community
+Initiatives][ci].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [mit-license]: https://opensource.org/licenses/mit-license.html
-[ci]: http://communityin.org/
+[ci]: https://communityin.org/
 [osi]: https://opensource.org

--- a/inst/templates/setup-template.txt
+++ b/inst/templates/setup-template.txt
@@ -2,12 +2,17 @@
 title: Setup
 ---
 
-Setup instructions live in this document. Please specify the tools and the data
-sets the Learner needs to have installed.
+FIXME: Setup instructions live in this document. Please specify the tools and
+the data sets the Learner needs to have installed.
 
 ## Data Sets
 
-Download the [data zip file](data/data.zip) and unzip it to your Desktop
+<!--
+FIXME: place any data you want learners to use in `episodes/data` and then use
+       a relative link ( [data zip file](data/lesson-data.zip) ) to provide a
+       link to it, replacing the example.com link.
+-->
+Download the [data zip file](https://example.com/FIXME) and unzip it to your Desktop
 
 ## Software Setup
 

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -26,6 +26,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item François Michonneau \email{francois@carpentries.org} [contributor]
+  \item Julien Colomb (\href{https://orcid.org/0000-0002-3127-5520}{ORCID}) [contributor]
   \item Toby Hodges \email{tobyhodges@carpentries.org} [contributor]
 }
 


### PR DESCRIPTION
This fixes the LICENSE, CONTRIBUTING, README and learners/setup templates to conform to pegboard version 0.5.1 and so that they are a bit more accurate to our lessons as they stand. 

@tobyhodges, could you check the language of the templates? 

it also fixes an error in the DESCRIPTION where the minimum version of pandoc was misconstrued.