### PR TITLE
do not convert links to markdown data files to html

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.15
+Version: 0.11.16
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.11.16 (unreleased)
+
+## BUG FIX
+
+- links to markdown files under `episodes/{data,fig,files}` folders are no
+  longer converted to html extensions. 
+
 # sandpaper 0.11.15 (2023-04-05)
 
 ## BUG FIX

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -423,7 +423,15 @@ flatten_links = function(el)
   -- link.md goes to link.html
   -- link.md#section1 goes to link.html#section1
   local proto = text.sub(tgt, 1, 4)
-  if proto ~= "http" and proto ~= "ftp:" then
+  -- We want to transformt the links only for local markdown files
+  -- TODO: revisit this to allow/disallow/retransform files that should be
+  -- included.
+  local our_prose = tgt:find("^https?:") == nil and
+    tgt:find("^ftp:") == nil and
+    tgt:find("^data/") == nil and
+    tgt:find("^files/") == nil and
+    tgt:find("^fig/") == nil
+  if our_prose then
     tgt,_ = tgt:gsub("%.R?md(#[%S]+)$", ".html%1")
     tgt,_ = tgt:gsub("%.R?md$", ".html")
   end

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -31,7 +31,8 @@
          ,Para [Str "This",Space,Link ("",[],[]) [Str "rmd",Space,Str "link",Space,Str "also"] ("01-Introduction.html","")]
          ,Para [Str "This",Space,Link ("",["newclass"],[]) [Str "rmd",Space,Str "is",Space,Str "safe"] ("https://example.com/01-Introduction.Rmd","")]
          ,Para [Str "This",Space,Link ("",[],[]) [Str "too"] ("Setup.html#windows-setup","windows setup")]
-         ,Para [Image ("fig-first",["imgclass"],[("alt","alt text")]) [Str "link",Space,Str "should",Space,Str "be",Space,Str "transformed"] ("fig/Setup.png","fig:")]]]]
+         ,Para [Image ("fig-first",["imgclass"],[("alt","alt text")]) [Str "link",Space,Str "should",Space,Str "be",Space,Str "transformed"] ("fig/Setup.png","fig:")]
+         ,Para [Str "This",Space,Link ("",[],[]) [Str "markdown",Space,Str "data",Space,Str "file",Space,Str "is",Space,Str "also",Space,Str "safe"] ("data/markdown-example.md","")]]]]
       ,Div ("accordionSolution1",["accordion","challenge-accordion","accordion-flush"],[])
        [Div ("",["accordion-item"],[])
         [RawBlock (Format "html") "<button class=\"accordion-button solution-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseSolution1\" aria-expanded=\"false\" aria-controls=\"collapseSolution1\">\n  <h4 class=\"accordion-header\" id=\"headingSolution1\">\n  Write now\n  </h4>\n</button>"
@@ -119,6 +120,7 @@
       <img src="fig/Setup.png" id="fig-first" class="imgclass" alt="alt text" alt="" />
       <p class="caption">link should be transformed</p>
       </div>
+      <p>This <a href="data/markdown-example.md">markdown data file is also safe</a></p>
       </div>
       </div>
       </div>

--- a/tests/testthat/examples/ex.md
+++ b/tests/testthat/examples/ex.md
@@ -31,6 +31,8 @@ This [too](learners/Setup.md#windows-setup 'windows setup')
 
 ![link should be transformed](../episodes/fig/Setup.png){#fig-first .imgclass alt='alt text'}
 
+This [markdown data file is also safe](data/markdown-example.md)
+
 ::: solution
 
 # Write now


### PR DESCRIPTION
This will prevent links to markdown files under `episodes/data` from being converted to HTML.

This issue was found in https://github.com/carpentries/lesson-transition/issues/60 where the lesson uses a markdown file as data. Transforming the link from a link to the github repository to a relative link cause it to accidentally transform to HTML.
