### PR TITLE
make serve() not always fail

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.15
+Version: 0.11.16
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.11.16 (2023-05-05)
+
+## BUG FIX
+
+* A failure to incrementally build the lesson with `sandpaper::serve()` has been
+  fixed (reported: @zkamvar, #450; fixed: @zkamvar, #451)
+
 # sandpaper 0.11.15 (2023-04-05)
 
 ## BUG FIX

--- a/R/serve.R
+++ b/R/serve.R
@@ -36,29 +36,32 @@
 # Note: we can not test this in covr because I'm not entirely sure of how to get
 #       it going
 serve <- function(path = ".") {
-  path <- root_path(path)
-  rend <- function(file_list = path) {
+  this_path <- root_path(path)
+  rend <- function(file_list = this_path) {
     for (f in file_list) {
       build_lesson(f, preview = FALSE)
     }
   }
   # path to the production folder that {servr} needs to render
-  prod <- fs::path(path_site(path), "docs")
+  prod <- fs::path(path_site(this_path), "docs")
   # filter function generator for {servr} to exclude the site folder
   #
   # This assumes that the input to the function will be whole file names
-  # which is the output of list.files() with recurse = TRUE and
+  # which is the output of list.files() with recurse = TRUE an
   # full.names = TRUE
   #
   # @param base the base path
-  make_filter <- function(base = path) {
+  make_filter <- function(base = this_path) {
     no_site <- file.path(base, "site")
     no_git  <- file.path(base, ".git")
     # return a filter function for the files
-    function(x) x[!startsWith(x, no_site) | !startsWith(x, no_git)]
+    function(x) {
+      x[!startsWith(x, no_site) | !startsWith(x, no_git)]
+    }
   }
+  this_filter <- make_filter(this_path)
   # to start, build the site and then watch things:
-  rend()
-  servr::httw(prod, watch = path, filter = make_filter(path), handler = rend)
+  rend(this_path)
+  servr::httw(prod, watch = this_path, filter = this_filter, handler = rend)
 }
 #nocov end

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,6 +33,13 @@ parent_calls_contain <- function(search = NULL, calls = sys.calls()) {
   # be the call that triggered the chain of command.
   for (call in calls) {
     # the first part of the call will be the function name
+    if (!inherits(call[[1]], "name")) {
+      # but sometimes it will be an anyonymous function, such as the
+      # onWSMessage function from httpuv:
+      # https://github.com/rstudio/httpuv/blob/faada3a19965af80289919308587836d22198a24/R/httpuv.R#L285-L293
+      # in these cases, we must skip
+      next
+    }
     fn <- as.character(call[[1L]])
     # pkg::function is parsed as the character c("::", "pkg", "function")
     # because "::" is a function, thus if we have 3, we take the function name


### PR DESCRIPTION
`sandpaper::serve()` was giving weird messages like

```r
<simpleError in as.character(call[[1L]]): cannot coerce type 'closure' to vector of type 'character'>
```

and not building past the 404 page. This PR fixes the issue. 

Unfortunately, I cannot add tests because I am not sure how to add tests for an interactive server function. 

This will fix #450