### PR TITLE
allow {renv} to produce no messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.16
+Version: 0.11.17
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.11.17 (unreleased)
+
+## TEST SUITE
+
+* An upstream feature in {renv}, forcing it to be silent when testing caused
+  some expectations to fail. This has been fixed in specific tests by turning
+  verbosity on in those tests (reported: @zkamvar, #457; fixed: @zkamvar, #458)
+
 # sandpaper 0.11.16 (2023-05-05)
 
 ## BUG FIX

--- a/R/package_cache.R
+++ b/R/package_cache.R
@@ -13,11 +13,11 @@
 #'
 #' Once you have a package cache defined, you can use changes in the lockfile to
 #' trigger rebuilds of the lesson. To do this, you can use:
-#' 
+#'
 #'   - `package_cache_trigger(TRUE)`
 #'
 #' The above function is best used in conjunction with [update_cache()]
-#' 
+#'
 #'
 #' @details
 #'
@@ -31,7 +31,7 @@
 #'    lesson website, which may result in strange errors, warnings, or incorrect
 #'    output.
 #' 2. You might be very cautious about updating any components of your current
-#'    R infrastructure because your work depends on you having the correct 
+#'    R infrastructure because your work depends on you having the correct
 #'    package versions installed.
 #'
 #' To alleviate these concerns, \pkg{sandpaper} uses the \pkg{renv} package to
@@ -54,8 +54,8 @@
 #' ## I have used \pkg{renv} before; how do I turn it off before sandpaper loads?
 #'
 #' You can set `options(sandpaper.use_renv = FALSE)` before loading {sandpaper}.
-#' 
-#' @param prompt if `TRUE` (default when interactive), a prompt for consent 
+#'
+#' @param prompt if `TRUE` (default when interactive), a prompt for consent
 #'   giving information about the proposed modifications will appear on the
 #'   screen asking for the user to choose to apply the changes or not.
 #' @param quiet if `TRUE`, messages will not be issued unless `prompt = TRUE`.
@@ -92,7 +92,8 @@ use_package_cache <- function(prompt = interactive(), quiet = !prompt) {
   if (getOption("sandpaper.use_renv") || !prompt) {
     options(sandpaper.use_renv = TRUE)
     msg <- try_use_renv(force = TRUE)
-    if (grepl("nothing to do", msg))  {
+    consent_provided <- if (is_testing()) TRUE else grepl("nothing to do", msg)
+    if (consent_provided)  {
       info <- consent_ok
     } else {
       info <- "{consent_ok}\n{.emph {msg}}"

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,6 +20,10 @@ example_can_run <- function(need_git = FALSE, skip_cran = TRUE) {
   run_ok
 }
 
+is_testing <- function() {
+  identical(Sys.getenv("TESTTHAT"), "true")
+}
+
 # Search parent calls for a specific set of function signatures and return TRUE
 # if any one of them match.
 parent_calls_contain <- function(search = NULL, calls = sys.calls()) {

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -43,6 +43,7 @@ test_that("manage_deps() will create a renv folder", {
 
   skip_on_cran()
   skip_on_os("windows")
+  withr::local_options(list("renv.verbose" = TRUE))
   rnv <- fs::path(lsn, "renv")
   # need to move renv folder outside of the lesson or it will detect the
   # suggested packages within the package and chaos will ensue
@@ -59,7 +60,7 @@ test_that("manage_deps() will create a renv folder", {
   suppressMessages({
     build_markdown(lsn, quiet = FALSE) %>%
       expect_message("Consent to use package cache provided") %>%
-      expect_output("Lockfile written to")
+      expect_output("knitr")
   })
 
   expect_true(fs::dir_exists(rnv))
@@ -76,6 +77,7 @@ test_that("manage_deps() will run without callr", {
 
   skip_on_cran()
   skip_on_os("windows")
+  withr::local_options(list("renv.verbose" = TRUE))
   withr::local_envvar(list(
     "RENV_PROFILE" = "lesson-requirements",
     "R_PROFILE_USER" = fs::path(tempfile(), "nada"),
@@ -128,6 +130,7 @@ test_that("pin_version() will use_specific versions", {
   skip_on_os("windows")
   skip_if_offline()
 
+  withr::local_options(list("renv.verbose" = TRUE))
   withr::local_envvar(list(
     "RENV_PROFILE" = "lesson-requirements",
     "R_PROFILE_USER" = fs::path(tempfile(), "nada"),
@@ -196,6 +199,8 @@ test_that("update_cache() will update old package versions", {
   skip_on_os("windows")
   skip_if_offline()
   skip_if(covr::in_covr())
+
+  withr::local_options(list("renv.verbose" = TRUE))
 
   suppressMessages({
     res <- update_cache(path = fs::path(lsn, "episodes"), prompt = FALSE, quiet = FALSE) %>%

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -146,12 +146,14 @@ test_that("pin_version() will use_specific versions", {
   # that might make provisioning packages a tricky business.
   skip_if(covr::in_covr())
 
+  withr::local_options(list("renv.verbose" = FALSE))
   suppressMessages({
-    # sessioninfo 1.2.0 dropped withr and cli as dependencies, so we should
-    # expect them to appear here
-    expect_output(res <- manage_deps(lsn), "withr")
+    capture.output(res <- manage_deps(lsn))
   })
 
+  # sessioninfo 1.2.0 dropped withr as a dependency, so we should
+  # expect it to appear here
+  expect_false(is.null(res$Packages$withr))
   expect_equal(res$Packages$sessioninfo$Version, "1.1.0")
 
 })

--- a/tests/testthat/test-utils-callr.R
+++ b/tests/testthat/test-utils-callr.R
@@ -37,6 +37,8 @@ test_that("callr_build_episode_md() works with Rmarkdown", {
 test_that("callr_build_episode_md() works with Rmarkdown using renv", {
 
   skip_on_os("windows")
+  withr::local_options(list("renv.verbose" = TRUE))
+
   fs::file_delete(o2)
   expect_false(fs::file_exists(o2))
   suppressMessages({


### PR DESCRIPTION
This will fix the testing suite to accomodate the new version of {renv} that has recently (in the past week) been pushed to rstudio/renv.

This will fail initially, but allow me to begin to address #457