### PR TITLE
ensure the same loaded pandoc version is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.11.17
+Version: 0.11.18
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.11.18 (unreleased)
+
+## MISC
+
+* The internal function `sandpaper:::render_html()` now explicitly sets the
+  pandoc version before running the subprocess. This allows lesson developers to
+  use the {pandoc} package to set their pandoc versions. (reported: @zkamvar,
+  #465; fixed: @zkamvar, #465)
+
 # sandpaper 0.11.17 (2023-05-16)
 
 ## NEW FEATURES

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -2,11 +2,11 @@
 #'
 #' This uses [rmarkdown::pandoc_convert()] to render HTML from a markdown file.
 #' We've specified pandoc extensions that align with the features desired in the
-#' Carpentries such as `markdown_in_html_blocks`, `tex_math_dollars`, and 
+#' Carpentries such as `markdown_in_html_blocks`, `tex_math_dollars`, and
 #' `native_divs`.
 #'
 #' @param path_in path to a markdown file
-#' @param quiet if `TRUE`, no output is produced. Default is `FALSE`, which 
+#' @param quiet if `TRUE`, no output is produced. Default is `FALSE`, which
 #'   reports the markdown build via pandoc
 #' @param ... extra options (e.g. lua filters) to be passed to pandoc
 #'
@@ -18,12 +18,12 @@
 #' if (rmarkdown::pandoc_available("2.11")) {
 #' # first example---markdown to HTML
 #' tmp <- tempfile()
-#' ex <- c("# Markdown", 
-#'   "", 
-#'   "::: challenge", 
-#'   "", 
+#' ex <- c("# Markdown",
+#'   "",
+#'   "::: challenge",
+#'   "",
 #'   "How do you write markdown divs?",
-#'   "", 
+#'   "",
 #'   ":::"
 #' )
 #' writeLines(ex, tmp)
@@ -46,7 +46,7 @@ render_html <- function(path_in, ..., quiet = FALSE) {
   on.exit(unlink(htm), add = TRUE)
   links <- getOption("sandpaper.links")
   if (length(links) && fs::file_exists(links)) {
-    # if we have links, we concatenate our input files 
+    # if we have links, we concatenate our input files
     tmpin <- tempfile(fileext = ".md")
     fs::file_copy(path_in, tmpin)
     cat("\n", file = tmpin, append = TRUE)
@@ -56,7 +56,16 @@ render_html <- function(path_in, ..., quiet = FALSE) {
   }
   args <- construct_pandoc_args(path_in, output = htm, to = "html", ...)
   sho <- !(quiet || identical(Sys.getenv("TESTTHAT"), "true"))
-  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args, 
+  # Ensure we use the _loaded version_ of pandoc in case folks are using
+  # the {pandoc} package: https://github.com/carpentries/sandpaper/issues/465
+  this_pandoc <- rmarkdown::find_pandoc()
+  callr::r(function(d, v, ...) {
+    rmarkdown::find_pandoc(dir = d, version = v)
+    rmarkdown::pandoc_convert(...)
+  },
+    args = c(d = as.character(this_pandoc$dir),
+      v = as.character(this_pandoc$version),
+      args),
     show = !quiet, spinner = sho)
   paste(readLines(htm), collapse = "\n")
 }
@@ -87,8 +96,8 @@ construct_pandoc_args <- function(path_in, output, to = "html", ...) {
     to      = to,
     options = c(
       "--preserve-tabs",
-      "--indented-code-classes=sh", 
-      "--section-divs", 
+      "--indented-code-classes=sh",
+      "--section-divs",
       "--mathjax",
       ...,
       "--lua-filter",


### PR DESCRIPTION
This PR will allow people to use the {pandoc} package to build a lesson with a
specific version of pandoc: 


```r
pandoc::pandoc_activate("latest")
sandpaper::build_lesson()
```


This will fix #465
