### PR TITLE
fix block anchors

### DIFF
--- a/R/render_html.R
+++ b/R/render_html.R
@@ -2,11 +2,11 @@
 #'
 #' This uses [rmarkdown::pandoc_convert()] to render HTML from a markdown file.
 #' We've specified pandoc extensions that align with the features desired in the
-#' Carpentries such as `markdown_in_html_blocks`, `tex_math_dollars`, and 
+#' Carpentries such as `markdown_in_html_blocks`, `tex_math_dollars`, and
 #' `native_divs`.
 #'
 #' @param path_in path to a markdown file
-#' @param quiet if `TRUE`, no output is produced. Default is `FALSE`, which 
+#' @param quiet if `TRUE`, no output is produced. Default is `FALSE`, which
 #'   reports the markdown build via pandoc
 #' @param ... extra options (e.g. lua filters) to be passed to pandoc
 #'
@@ -18,12 +18,12 @@
 #' if (rmarkdown::pandoc_available("2.11")) {
 #' # first example---markdown to HTML
 #' tmp <- tempfile()
-#' ex <- c("# Markdown", 
-#'   "", 
-#'   "::: challenge", 
-#'   "", 
+#' ex <- c("# Markdown",
+#'   "",
+#'   "::: challenge",
+#'   "",
 #'   "How do you write markdown divs?",
-#'   "", 
+#'   "",
 #'   ":::"
 #' )
 #' writeLines(ex, tmp)
@@ -46,7 +46,7 @@ render_html <- function(path_in, ..., quiet = FALSE) {
   on.exit(unlink(htm), add = TRUE)
   links <- getOption("sandpaper.links")
   if (length(links) && fs::file_exists(links)) {
-    # if we have links, we concatenate our input files 
+    # if we have links, we concatenate our input files
     tmpin <- tempfile(fileext = ".md")
     fs::file_copy(path_in, tmpin)
     cat("\n", file = tmpin, append = TRUE)
@@ -56,7 +56,7 @@ render_html <- function(path_in, ..., quiet = FALSE) {
   }
   args <- construct_pandoc_args(path_in, output = htm, to = "html", ...)
   sho <- !(quiet || identical(Sys.getenv("TESTTHAT"), "true"))
-  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args, 
+  callr::r(function(...) rmarkdown::pandoc_convert(...), args = args,
     show = !quiet, spinner = sho)
   paste(readLines(htm), collapse = "\n")
 }
@@ -87,8 +87,8 @@ construct_pandoc_args <- function(path_in, output, to = "html", ...) {
     to      = to,
     options = c(
       "--preserve-tabs",
-      "--indented-code-classes=sh", 
-      "--section-divs", 
+      "--indented-code-classes=sh",
+      "--section-divs",
       "--mathjax",
       ...,
       "--lua-filter",

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -88,8 +88,22 @@ fix_callouts <- function(nodes = NULL) {
   h3 <- xml2::xml_find_all(callouts, "./div/h3")
   xml2::xml_set_attr(h3, "class", "callout-title")
   inner_div <- xml2::xml_parent(h3)
+  # remove the "section level3 callout-title" attrs
   xml2::xml_set_attr(inner_div, "class", "callout-inner")
-  add_anchors(h3, xml2::xml_attr(callouts, "id"))
+  # Get the heading IDS (because we use section headings, the IDs are anchored
+  # to the section div and not the heading element)
+  # <div class="section level3 callout-title callout-inner">
+  #   <h3>Heading for this callout</h3>
+  # </div>
+  ids <- xml2::xml_attr(inner_div, "id")
+  # get the callout ID in the cases where they are missing
+  replacements <- xml2::xml_attr(callouts, "id")
+  ids <- ifelse(is.na(ids), replacements, ids)
+  # add the anchors and then set the attributes in the correct places.
+  add_anchors(h3, ids)
+  xml2::xml_set_attr(h3, "id", NULL)
+  # we replace the callout ID with the correct ID
+  xml2::xml_set_attr(callouts, "id", ids)
   invisible(nodes)
 }
 

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -277,8 +277,6 @@ callout_block = function(el)
   -- Get the header and create the ID
   local header = get_header(el, 3)
 
-  print(make_id(header))
-
   block_counts[classes[1]] = block_counts[classes[1]] + 1
   callout_id = classes[1]..block_counts[classes[1]]
   classes:insert(1, "callout")

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -9,6 +9,15 @@ function Set (list)
   return set
 end
 
+-- Function to round trip with pandoc to make a heading ID
+function make_id (heading, via)
+  local via = via or 'html'
+  local heading = pandoc.Header(1, inlines)
+  local temp_doc = pandoc.Pandoc{heading}
+  local roundtripped_doc = pandoc.read(pandoc.write(temp_doc, via), via)
+  return roundtripped_doc.blocks[1].identifier
+end
+
 
 local blocks = {
   ["callout"] = "bell",
@@ -265,10 +274,14 @@ callout_block = function(el)
   if this_icon == nil then
     return el
   end
+  -- Get the header and create the ID
+  local header = get_header(el, 3)
+
+  print(make_id(header))
+
   block_counts[classes[1]] = block_counts[classes[1]] + 1
   callout_id = classes[1]..block_counts[classes[1]]
   classes:insert(1, "callout")
-  local header = get_header(el, 3)
 
   local icon = pandoc.RawBlock("html",
   "<i class='callout-icon' data-feather='"..this_icon.."'></i>")

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -9,16 +9,6 @@ function Set (list)
   return set
 end
 
--- Function to round trip with pandoc to make a heading ID
-function make_id (heading, via)
-  local via = via or 'html'
-  local heading = pandoc.Header(1, inlines)
-  local temp_doc = pandoc.Pandoc{heading}
-  local roundtripped_doc = pandoc.read(pandoc.write(temp_doc, via), via)
-  return roundtripped_doc.blocks[1].identifier
-end
-
-
 local blocks = {
   ["callout"] = "bell",
   ["objectives"] = "none",

--- a/tests/testthat/examples/callout-ids.html
+++ b/tests/testthat/examples/callout-ids.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+  <body>
+    <div id="markdown" class="section level2">
+      <h2>Markdown</h2>
+      <p>Here is an example of a callout block</p>
+      <div id="discussion1" class="callout discussion">
+        <div class="callout-square">
+          <i class="callout-icon" data-feather="message-circle"></i>
+        </div>
+        <div class="section level3 callout-title callout-inner">
+          <h3 class="callout-title">Challenge</h3>
+          <div class="callout-content">
+            <p>How do you write markdown divs?</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="prereq1" class="callout prereq">
+      <div class="callout-square">
+        <i class="callout-icon" data-feather="check"></i>
+      </div>
+      <div id="wait-what" class="section level3 callout-title callout-inner">
+        <h3 class="callout-title">Wait what?</h3>
+        <div class="callout-content">
+          <p>preeeee</p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -24,6 +24,27 @@ test_that("paths in instructor view that are nested or not HTML get diverted", {
 })
 
 
+test_that("callout ids are processed correctly", {
+  html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
+  fix_callouts(html_test)
+  anchors <- xml2::xml_find_all(html_test, ".//a")
+  headings <- xml2::xml_find_all(html_test, ".//h3")
+  callouts <- xml2::xml_find_all(html_test,
+    ".//div[starts-with(@class, 'callout ')]")
+  expect_length(anchors, 2)
+  expect_length(callouts, 2)
+  expect_length(headings, 2)
+  # headings should not have IDS
+  expect_equal(xml2::xml_has_attr(headings, "id"), c(FALSE, FALSE))
+  # callouts should have these IDS
+  expect_equal(xml2::xml_has_attr(callouts, "id"), c(TRUE, TRUE))
+  # The IDs should be what we expect
+  ids <- xml2::xml_attr(callouts, "id")
+  expect_equal(ids, c("discussion1", "wait-what"))
+  # The IDs should match the anchors
+  expect_equal(paste0("#", ids), xml2::xml_attr(anchors, "href"))
+})
+
 
 test_that("empty args result in nothing happening", {
   expect_null(fix_nodes())


### PR DESCRIPTION
This fixes post-processing of the HTML where the callout blocks will be given the correct anchors and correct IDs.


This will fix #454
