### PR TITLE
do not use gert for pkgdown config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.12.2
+Version: 0.12.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# sandpaper 0.12.3 (2023-06-01)
+
+* A bug where the git credentials are accidentally changed when a lesson is
+  built is fixed by no longer querying git author when the lesson is built.
+  (reported: @joelnitta, @velait, and @zkamvar, #449; fixed: @zkamvar, #476).
+
 # sandpaper 0.12.2 (2023-05-29)
 
 ## BUG FIX

--- a/R/create_site.R
+++ b/R/create_site.R
@@ -10,7 +10,6 @@ create_site <- function(path) {
 
   if (!isTRUE(chk$description)) {
     fs::file_create(fs::path(path_site(path), "DESCRIPTION"))
-    check_git_user(path)
     create_description(path)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -166,7 +166,7 @@ create_site_readme <- function(path) {
 
 create_description <- function(path) {
   yaml <- yaml::read_yaml(path_config(path), eval.expr = FALSE)
-  the_author <- paste(gert::git_signature_default(path), "[aut, cre]")
+  the_author <- paste("Jo Carpenter <team@carpentries.org> [aut, cre]")
   the_author <- utils::as.person(the_author)
   desc <- desc::description$new("!new")
   desc$del(c("BugReports", "LazyData"))

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -36,7 +36,7 @@ pkg <- pkgdown::as_pkgdown(fs::path_dir(sitepath))
 
 test_that("The lesson contact is always team@carpentries.org", {
   dsc <- desc::description$new(sub("docs[/]?", "DESCRIPTION", sitepath))
-  auth <- eval(parse(text = x$get_field("Authors@R")))
+  auth <- eval(parse(text = dsc$get_field("Authors@R")))
   expect_equal(as.character(auth),
     "Jo Carpenter <team@carpentries.org> [aut, cre]")
 })

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -33,6 +33,15 @@ if (rmarkdown::pandoc_available("2.11")) {
 
 pkg <- pkgdown::as_pkgdown(fs::path_dir(sitepath))
 
+
+test_that("The lesson contact is always team@carpentries.org", {
+  dsc <- desc::description$new(sub("docs[/]?", "DESCRIPTION", sitepath))
+  auth <- eval(parse(text = x$get_field("Authors@R")))
+  expect_equal(as.character(auth),
+    "Jo Carpenter <team@carpentries.org> [aut, cre]")
+})
+
+
 test_that("build_lesson() also builds the extra pages", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   expect_true(fs::dir_exists(sitepath))


### PR DESCRIPTION
This removes a check_git_user() and a call to {gert} in the process of building a lesson as it is not needed. 

This will address https://github.com/carpentries/sandpaper/issues/449, but I won't say fix because it may still be an issue when people create lessons.

It remains to be seen if this will address https://github.com/carpentries-incubator/statistical-probabilistic-programming-r/issues/1
