### PR TITLE
fix template page permissions issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.12.3
+Version: 0.12.4
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# sandpaper 0.12.4 (unreleased)
+
+* A bug in walled systems where templated pages (e.g. 404) could not be written
+  due to permissions issues has been fixed (reported: @ocaisa, #479; fixed:
+  @zkamvar, #482).
+
 # sandpaper 0.12.3 (2023-06-01)
 
 * A bug where the git credentials are accidentally changed when a lesson is

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -49,6 +49,9 @@ render_html <- function(path_in, ..., quiet = FALSE) {
     # if we have links, we concatenate our input files
     tmpin <- tempfile(fileext = ".md")
     fs::file_copy(path_in, tmpin)
+    # if the file is not readable by the user, then we need to make it readable
+    # https://github.com/carpentries/sandpaper/issues/479
+    fs::file_chmod(tmpin, "u+w")
     cat("\n", file = tmpin, append = TRUE)
     file.append(tmpin, links)
     path_in <- tmpin

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -49,7 +49,7 @@ render_html <- function(path_in, ..., quiet = FALSE) {
     # if we have links, we concatenate our input files
     tmpin <- tempfile(fileext = ".md")
     fs::file_copy(path_in, tmpin)
-    # if the file is not readable by the user, then we need to make it readable
+    # if the file is not writable by the user, then we need to make it writable
     # https://github.com/carpentries/sandpaper/issues/479
     fs::file_chmod(tmpin, "u+w")
     cat("\n", file = tmpin, append = TRUE)

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -11,7 +11,7 @@ test_that("sandpaper.links can be included", {
   expect_no_match(render_html(tmp), "\\[link at the end\\]")
 })
 
-test_that("sandpaper.links can be included even with read-only template", {
+test_that("sandpaper.links can be included even with read-only template file", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- withr::local_tempfile()
   tnk <- withr::local_tempfile()

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -11,6 +11,19 @@ test_that("sandpaper.links can be included", {
   expect_no_match(render_html(tmp), "\\[link at the end\\]")
 })
 
+test_that("sandpaper.links can be included even with read-only template", {
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+  tmp <- withr::local_tempfile()
+  tnk <- withr::local_tempfile()
+  writeLines("This has a [link at the end] in a separate file[^1]\n\n[^1]: :)", tmp)
+
+  perm <- fs::file_info(tmp)$permissions
+  withr::defer(fs::file_chmod(tmp, perm), priority = "first")
+  fs::file_chmod(tmp, "a-w")
+  writeLines("[link at the end]: https://example.com/link", tnk)
+  withr::local_options(list("sandpaper.links" = tnk))
+  expect_no_match(render_html(tmp), "\\[link at the end\\]")
+})
 
 test_that("tabs are preserved", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
@@ -63,7 +76,7 @@ test_that("footnotes are rendered", {
 })
 
 test_that("pandoc structure is rendered correctly", {
-  
+
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   out <- fs::file_temp()
   withr::local_file(out)
@@ -83,7 +96,7 @@ test_that("pandoc structure is rendered correctly", {
 })
 
 test_that("paragraphs after objectives block are parsed correctly", {
-  
+
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   tmp <- fs::file_temp()
   out <- fs::file_temp()
@@ -136,7 +149,7 @@ test_that("render_html applies the internal lua filter", {
   formation = function(x) {
     x <- sub("[<]div id[=]\"collapseSolution1\".+", "[solution collapse]", x)
     sub("[<]div id[=]\"collapseInstructor1\".+", "[instructor collapse]", x)
-    
+
   }
   expect_snapshot(cat(res), transform = formation)
 })
@@ -194,5 +207,5 @@ test_that("render_html applies external lua filters", {
   writeLines(lu, lua)
   res <- render_html(example_markdown, paste0("--lua-filter=", lua))
   expect_match(res, "<em>mowdrank</em> divs", fixed = TRUE)
-  
+
 })


### PR DESCRIPTION
This ensures that templated files have the right permissions when appending common links to them so that 404 pages and other generated content can be built.

This will fix #479

This PR can be tested by installing it with the `{pak}` OR `{remotes}` package:


```r
# via {pak}
# install.packages("pak")
pak::pkg_install("carpentries/sandpaper#482")

# via {remotes}
# install.packages("remotes")
remotes::install_github("carpentries/sandpaper#482")
```
