### PR TITLE
Improve JSON-LD conformation to BioSchemas profile

### DIFF
--- a/inst/templates/metadata-template.txt
+++ b/inst/templates/metadata-template.txt
@@ -1,13 +1,13 @@
 {{=<% %>=}}
 {
   "@context": "https://schema.org",
-  "@type": "TrainingMaterial",
+  "@type": "LearningResource",
   "@id": "<% url %>",
-  "dct:conformsTo": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",
+  "http://purl.org/dc/terms/conformsTo": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",
   "description": "<% desc %><% ^desc %>A Carpentries Lesson teaching foundational data and coding skills to researchers worldwide<% /desc %>",
   "keywords": "<% keywords %><% ^keywords %>software,data,lesson,The Carpentries<% /keywords %>",
   "name": "<% &pagetitle %>",
-  "creativeWorkStatus": "active",
+  "creativeWorkStatus": "Active",
   "url": "<% url %>",
   "identifier": "<% url %>",
   <% #date %>"dateCreated": "<% created %>",


### PR DESCRIPTION
This addresses some of the suggestions I made in #481. I don't think I can address all the points (and I would like to discuss some of them before they are worked on), but I can remove the duplicate URLs if that is okay.

This currently makes the following changes:

- use `LearningResource` as type
- expand `dct:conformsTo` to full URI
- use (still hardcoded) `Active` as `creativeWorkStatus` (taken from <https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE>)
