### PR TITLE
Fix test for {renv}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.12.4
+Version: 0.12.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,7 +75,7 @@ Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
-Config/Needs/check: rstudio/renv, rstudio/rmarkdown
+Config/Needs/check: rstudio/renv
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 URL: https://carpentries.github.io/sandpaper/, https://github.com/carpentries/sandpaper/, https://carpentries.github.io/workbench/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,7 +75,7 @@ Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3
 Config/testthat/parallel: false
-Config/Needs/check: rstudio/renv
+Config/Needs/check: rstudio/renv, rstudio/rmarkdown
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 URL: https://carpentries.github.io/sandpaper/, https://github.com/carpentries/sandpaper/, https://carpentries.github.io/workbench/

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * A broken test from the development version of {renv} fixed. This was a change
   in output and not functionality, so there will be no user-visible changes
   (reported: @zkamvar, #484; fixed: @zkamvar, #487).
+* Broken snapshot tests from upstream R-devel have been fixed by ensuring that
+  version comparisons always use characters and not numbers (which is
+  ergonomically weird, but whatever) (reported: @zkamvar #487; fixed: @zkamvar
+  #487)
 
 # sandpaper 0.12.4 (2023-06-16)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,22 @@
-# sandpaper 0.12.4 (unreleased)
+# sandpaper 0.12.5 (unreleased)
+
+## BUG FIX
+
+* A broken test from the development version of {renv} fixed. This was a change
+  in output and not functionality, so there will be no user-visible changes
+  (reported: @zkamvar, #484; fixed: @zkamvar, #487).
+
+# sandpaper 0.12.4 (2023-06-16)
+
+## BUG FIX
 
 * A bug in walled systems where templated pages (e.g. 404) could not be written
   due to permissions issues has been fixed (reported: @ocaisa, #479; fixed:
   @zkamvar, #482).
 
 # sandpaper 0.12.3 (2023-06-01)
+
+## BUG FIX
 
 * A bug where the git credentials are accidentally changed when a lesson is
   built is fixed by no longer querying git author when the lesson is built.

--- a/R/check_pandoc.R
+++ b/R/check_pandoc.R
@@ -38,7 +38,8 @@ check_pandoc <- function(quiet = TRUE, pv = "2.11", rv = "1.4") {
   } else {
     # Are we in an RStudio session?
     msg <- "{.pkg sandpaper} requires pandoc version {.field {pv}} or higher."
-    #
+    # This avoids spurious warnings in R > "4.3.0"
+    # See <https://bugs.r-project.org/show_bug.cgi?id=18548>
     if (pan$version > "0") {
       pan_msg <- "You have pandoc version {.field {panver}} in {.file {pandir}}"
     } else {

--- a/R/check_pandoc.R
+++ b/R/check_pandoc.R
@@ -38,7 +38,8 @@ check_pandoc <- function(quiet = TRUE, pv = "2.11", rv = "1.4") {
   } else {
     # Are we in an RStudio session?
     msg <- "{.pkg sandpaper} requires pandoc version {.field {pv}} or higher."
-    if (pan$version > 0) {
+    #
+    if (pan$version > "0") {
       pan_msg <- "You have pandoc version {.field {panver}} in {.file {pandir}}"
     } else {
       pan_msg <- "You do not have pandoc installed on your PATH"

--- a/tests/testthat/test-utils-callr.R
+++ b/tests/testthat/test-utils-callr.R
@@ -46,10 +46,12 @@ test_that("callr_build_episode_md() works with Rmarkdown using renv", {
     path = t2, hash = NULL, workenv = new.env(),
     outpath = o2, workdir = fs::path_dir(o2), root = lsn, quiet = TRUE
   ) %>%
-    expect_output("\\(lesson-requirements\\)")
+    expect_output("lesson-requirements") # Looking for a report of the lesson-requirements profile from {renv}
   })
   expect_true(fs::file_exists(o2))
+  # our R expression was evaluated
   expect_match(grep("Hello", readLines(o2), value = TRUE), "Hello from R (version|Under)")
+  # The CSS code is evaluated
   expect_match(grep("css", readLines(o2), value = TRUE), "style type=.text/css.")
 
 })


### PR DESCRIPTION
This fixes a single test for {renv} due to a difference in output it created.

Note: because this only affects one test and the devel version of {renv}, the new version does not need to be released after this is merged. 

This will fix #484 