### PR TITLE
Fix typos and deprecated fct `check_` in the README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -159,7 +159,7 @@ The functions in {sandpaper} have the following prefixes:
  - `create_` will create/amend files or folders in your workspace
  - `update_` will update build resources in the lesson
  - `build_` will build files from your source
- - `check_` validates either the elements of the lesson and/or episodes
+ - `validate_` will check the validity of either the elements of the lesson and/or episodes
  - `fetch_` will download files or resources from the internet
  - `reset_` removes files or information
  - `get_` will retrieve information from your source files as an R object
@@ -184,7 +184,7 @@ Accessors
 
 **Website Creation and Validation**
 
- - `check_lesson()` checks and validates the source files and lesson structure
+ - `validate_lesson()` checks and validates the source files and lesson structure
  - `build_episode_md()` renders an individual file to markdown (internal use)
  - `build_episode_html()` renders a built markdown file to html (internal use)
  - `build_lesson()` builds the lesson into a static website
@@ -325,7 +325,7 @@ The typical workflow will look like this:
 
 
 ```{r}
-sandpaper::check_lesson() # validates the structure of the input files
+sandpaper::validate_lesson() # validates the structure of the input files
 sandpaper::build_lesson() # builds and validates lesson
 ```
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -48,7 +48,7 @@ reference:
    - reset_episodes
    - reset_site
    - strip_prefix
- - title: "The Pacakge Cache"
+ - title: "The Package Cache"
    desc: >
      Lessons with generated content (R Markdown lessons) have an extra file 
      called `renv/profiles/lesson-requirments/renv.lock` that records the

--- a/inst/workflows/README.md
+++ b/inst/workflows/README.md
@@ -96,7 +96,7 @@ are okay.
 
 This update is run ~~weekly or~~ on demand.
 
-### 03 Maintain: Update Pacakge Cache (update-cache.yaml)
+### 03 Maintain: Update Package Cache (update-cache.yaml)
 
 For lessons that have generated content, we use {renv} to ensure that the output
 is stable. This is controlled by a single lockfile which documents the packages

--- a/tests/testthat/_snaps/manage_deps.md
+++ b/tests/testthat/_snaps/manage_deps.md
@@ -1,4 +1,4 @@
-# pacakge cache message appears correct [plain]
+# package cache message appears correct [plain]
 
     Code
       cat(paste(c("1:", "2:"), sandpaper:::message_package_cache(msg)), sep = "\n")
@@ -29,7 +29,7 @@
       1: Yes, please use the package cache (recommended)
       2: No, I want to use my default library
 
-# pacakge cache message appears correct [ansi]
+# package cache message appears correct [ansi]
 
     Code
       cat(paste(c("1:", "2:"), sandpaper:::message_package_cache(msg)), sep = "\n")

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -1,6 +1,6 @@
 lsn <- restore_fixture()
 
-cli::test_that_cli("pacakge cache message appears correct", {
+cli::test_that_cli("package cache message appears correct", {
 
   msg <- readLines(system.file("resources/WELCOME", package = "renv"))
   msg <- gsub("${RENV_PATHS_ROOT}", dQuote("/path/to/cache"), msg, fixed = TRUE)

--- a/vignettes/building-with-renv.Rmd
+++ b/vignettes/building-with-renv.Rmd
@@ -294,7 +294,7 @@ package_cache_trigger(FALSE) # prevent package cache from triggering rebuilds
 
 You might want to set this to `TRUE` when you pull changes from upstream.
 
-## Adding New Pacakges to the Cache
+## Adding New Packages to the Cache
 
 The {sandpaper} cache records ONLY the packages needed for the repository itself.
 This means that if you want to use a package, you _must_ have it declared 


### PR DESCRIPTION
Hello!
thanks for developing and maintaining this package! I spotted a few typos and mentions of the now deprecated function `check_lesson`, so I made a few changes.
Hope that helps!
Best, 