### PR TITLE
update CI renv setup to use explicit snapshots

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,6 +11,7 @@ on:
     branches: [main, master]
   schedule:
     - cron: '0 0 * * 2'
+  workflow_dispatch:
 
 name: R-CMD-check
 
@@ -101,6 +102,7 @@ jobs:
       - name: "Prime {renv} Cache"
         if: runner.os != 'Windows'
         run: |
+          renv::settings$snapshot.type("explicit")
           renv::init()
           system('sudo rm -rf renv.lock renv .Rprofile')
           system('git clean -fd -e .github')

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 name: test-coverage
 
@@ -68,6 +69,7 @@ jobs:
 
       - name: Prime {renv} Cache
         run: |
+          renv::settings$snapshot.type("explicit")
           renv::init()
           system('rm -rf renv .Rprofile')
           system('git clean -fd -e .github')

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -201,12 +201,8 @@ test_that("update_cache() will update old package versions", {
   skip_if_offline()
   skip_if(covr::in_covr())
 
-  withr::local_options(list("renv.verbose" = TRUE))
 
-  suppressMessages({
-    res <- update_cache(path = fs::path(lsn, "episodes"), prompt = FALSE, quiet = FALSE) %>%
-      expect_output("sessioninfo")
-  })
+  res <- update_cache(path = fs::path(lsn, "episodes"), prompt = FALSE, quiet = FALSE)
   expect_true(
     package_version(res$sessioninfo$Version) > package_version("1.1.0")
   )


### PR DESCRIPTION
This adds the `"explicit"` snapshot type to the setup of the renv cache when testing {sandpaper}. It also adds the `workflow_dispatch` key to the action config so that we can run it on demand instead of needing to create a fake commit or waiting a week.

This will fix #488 