### PR TITLE
use pandoc 2.19.2 in tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,8 +63,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
         if: runner.os != 'Windows'
-        with:
-          pandoc-version: '2.11'
 
       - name: "Windows: setup TMPDIR"
         if: runner.os == 'Windows'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,8 +26,6 @@ jobs:
 
       - name: "Set up pandoc"
         uses: r-lib/actions/setup-pandoc@v2
-        with:
-          pandoc-version: '2.11'
 
       - name: "Install sysreqs"
         id: run-apt

--- a/tests/testthat/_snaps/render_html.md
+++ b/tests/testthat/_snaps/render_html.md
@@ -3,73 +3,304 @@
     Code
       cat(readLines(out), sep = "\n")
     Output
-      [RawBlock (Format "text") ""
-      ,Div ("",["overview","card"],[])
-       [RawBlock (Format "html") "<h2 class='card-header'>Overview</h2>"
-       ,Div ("",["row","g-0"],[])
-        [Div ("",["col-md-4"],[])
-         [Div ("",["card-body"],[])
-          [Div ("",["inner"],[])
-           [RawBlock (Format "html") "<h3 class='card-title'>Questions</h3>"
-           ,BulletList
-            [[Plain [Str "What\8217s",Space,Str "the",Space,Str "point?"]]]]]]
-        ,Div ("",["col-md-8"],[])
-         [Div ("",["card-body"],[])
-          [Div ("",["inner","bordered"],[])
-           [RawBlock (Format "html") "<h3 class='card-title'>Objectives</h3>"
-           ,BulletList
-            [[Plain [Str "Bake",Space,Str "him",Space,Str "away,",Space,Str "toys"]]]]]]]]
-      ,Header 1 ("markdown",[],[]) [Str "Markdown"]
-      ,Div ("challenge1",["callout","challenge"],[])
-       [Div ("",["callout-square"],[])
-        [RawBlock (Format "html") "<i class='callout-icon' data-feather='zap'></i>"]
-       ,Div ("",["callout-inner"],[])
-        [Header 3 ("",["callout-title"],[]) [Str "Challenge"]
-        ,Div ("",["callout-content"],[])
-         [Para [Str "How",Space,Str "do",Space,Str "you",Space,Str "write",Space,Str "markdown",Space,Str "divs?"]
-         ,Para [Str "This",Space,Link ("",[],[]) [Str "link",Space,Str "should",Space,Str "be",Space,Str "transformed"] ("Setup.html","")]
-         ,Para [Str "This",Space,Link ("",[],[]) [Str "rmd",Space,Str "link",Space,Str "also"] ("01-Introduction.html","")]
-         ,Para [Str "This",Space,Link ("",["newclass"],[]) [Str "rmd",Space,Str "is",Space,Str "safe"] ("https://example.com/01-Introduction.Rmd","")]
-         ,Para [Str "This",Space,Link ("",[],[]) [Str "too"] ("Setup.html#windows-setup","windows setup")]
-         ,Para [Image ("fig-first",["imgclass"],[("alt","alt text")]) [Str "link",Space,Str "should",Space,Str "be",Space,Str "transformed"] ("fig/Setup.png","fig:")]]]]
-      ,Div ("accordionSolution1",["accordion","challenge-accordion","accordion-flush"],[])
-       [Div ("",["accordion-item"],[])
-        [RawBlock (Format "html") "<button class=\"accordion-button solution-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseSolution1\" aria-expanded=\"false\" aria-controls=\"collapseSolution1\">\n  <h4 class=\"accordion-header\" id=\"headingSolution1\">\n  Write now\n  </h4>\n</button>"
-        [solution collapse]
-         [Div ("",["accordion-body"],[])
-          [Para [Str "just",Space,Str "write",Space,Str "it,",Space,Str "silly."]]]]]
-      ,Div ("accordionInstructor1",["accordion","instructor-note","accordion-flush"],[])
-       [Div ("",["accordion-item"],[])
-        [RawBlock (Format "html") "<button class=\"accordion-button instructor-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseInstructor1\" aria-expanded=\"false\" aria-controls=\"collapseInstructor1\">\n  <h3 class=\"accordion-header\" id=\"headingInstructor1\">\n  <div class=\"note-square\"><i aria-hidden=\"true\" class=\"callout-icon\" data-feather=\"edit-2\"></i></div>\n  Instructor Note\n  </h3>\n</button>"
-        [instructor collapse]
-         [Div ("",["accordion-body"],[])
-          [Para [Str "This",Space,Str "should",Space,Str "be",Space,Str "aside"]]]]]
-      ,Div ("",["nothing"],[])
-       [Para [Str "This",Space,Str "should",Space,Str "be"]]]
+      [ RawBlock (Format "text") ""
+      , Div
+          ( "" , [ "overview" , "card" ] , [] )
+          [ RawBlock
+              (Format "html") "<h2 class='card-header'>Overview</h2>"
+          , Div
+              ( "" , [ "row" , "g-0" ] , [] )
+              [ Div
+                  ( "" , [ "col-md-4" ] , [] )
+                  [ Div
+                      ( "" , [ "card-body" ] , [] )
+                      [ Div
+                          ( "" , [ "inner" ] , [] )
+                          [ RawBlock
+                              (Format "html")
+                              "<h3 class='card-title'>Questions</h3>"
+                          , BulletList
+                              [ [ Plain
+                                    [ Str "What\8217s"
+                                    , Space
+                                    , Str "the"
+                                    , Space
+                                    , Str "point?"
+                                    ]
+                                ]
+                              ]
+                          ]
+                      ]
+                  ]
+              , Div
+                  ( "" , [ "col-md-8" ] , [] )
+                  [ Div
+                      ( "" , [ "card-body" ] , [] )
+                      [ Div
+                          ( "" , [ "inner" , "bordered" ] , [] )
+                          [ RawBlock
+                              (Format "html")
+                              "<h3 class='card-title'>Objectives</h3>"
+                          , BulletList
+                              [ [ Plain
+                                    [ Str "Bake"
+                                    , Space
+                                    , Str "him"
+                                    , Space
+                                    , Str "away,"
+                                    , Space
+                                    , Str "toys"
+                                    ]
+                                ]
+                              ]
+                          ]
+                      ]
+                  ]
+              ]
+          ]
+      , Header 1 ( "markdown" , [] , [] ) [ Str "Markdown" ]
+      , Div
+          ( "challenge1" , [ "callout" , "challenge" ] , [] )
+          [ Div
+              ( "" , [ "callout-square" ] , [] )
+              [ RawBlock
+                  (Format "html")
+                  "<i class='callout-icon' data-feather='zap'></i>"
+              ]
+          , Div
+              ( "" , [ "callout-inner" ] , [] )
+              [ Header
+                  3 ( "" , [ "callout-title" ] , [] ) [ Str "Challenge" ]
+              , Div
+                  ( "" , [ "callout-content" ] , [] )
+                  [ Para
+                      [ Str "How"
+                      , Space
+                      , Str "do"
+                      , Space
+                      , Str "you"
+                      , Space
+                      , Str "write"
+                      , Space
+                      , Str "markdown"
+                      , Space
+                      , Str "divs?"
+                      ]
+                  , Para
+                      [ Str "This"
+                      , Space
+                      , Link
+                          ( "" , [] , [] )
+                          [ Str "link"
+                          , Space
+                          , Str "should"
+                          , Space
+                          , Str "be"
+                          , Space
+                          , Str "transformed"
+                          ]
+                          ( "Setup.html" , "" )
+                      ]
+                  , Para
+                      [ Str "This"
+                      , Space
+                      , Link
+                          ( "" , [] , [] )
+                          [ Str "rmd"
+                          , Space
+                          , Str "link"
+                          , Space
+                          , Str "also"
+                          ]
+                          ( "01-Introduction.html" , "" )
+                      ]
+                  , Para
+                      [ Str "This"
+                      , Space
+                      , Link
+                          ( "" , [ "newclass" ] , [] )
+                          [ Str "rmd"
+                          , Space
+                          , Str "is"
+                          , Space
+                          , Str "safe"
+                          ]
+                          ( "https://example.com/01-Introduction.Rmd" , "" )
+                      ]
+                  , Para
+                      [ Str "This"
+                      , Space
+                      , Link
+                          ( "" , [] , [] )
+                          [ Str "too" ]
+                          ( "Setup.html#windows-setup" , "windows setup" )
+                      ]
+                  , Para
+                      [ Image
+                          ( "fig-first"
+                          , [ "imgclass" ]
+                          , [ ( "alt" , "alt text" ) ]
+                          )
+                          [ Str "link"
+                          , Space
+                          , Str "should"
+                          , Space
+                          , Str "be"
+                          , Space
+                          , Str "transformed"
+                          ]
+                          ( "fig/Setup.png" , "fig:" )
+                      ]
+                  ]
+              ]
+          ]
+      , Div
+          ( "accordionSolution1"
+          , [ "accordion"
+            , "challenge-accordion"
+            , "accordion-flush"
+            ]
+          , []
+          )
+          [ Div
+              ( "" , [ "accordion-item" ] , [] )
+              [ RawBlock
+                  (Format "html")
+                  "<button class=\"accordion-button solution-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseSolution1\" aria-expanded=\"false\" aria-controls=\"collapseSolution1\">\n  <h4 class=\"accordion-header\" id=\"headingSolution1\">\n  Write now\n  </h4>\n</button>"
+              , Div
+                  ( "collapseSolution1"
+                  , [ "accordion-collapse" , "collapse" ]
+                  , [ ( "[solution collapse]" )
+                    , ( "[solution collapse]" )
+                    ]
+                  )
+                  [ Div
+                      ( "" , [ "accordion-body" ] , [] )
+                      [ Para
+                          [ Str "just"
+                          , Space
+                          , Str "write"
+                          , Space
+                          , Str "it,"
+                          , Space
+                          , Str "silly."
+                          ]
+                      ]
+                  ]
+              ]
+          ]
+      , Div
+          ( "accordionInstructor1"
+          , [ "accordion" , "instructor-note" , "accordion-flush" ]
+          , []
+          )
+          [ Div
+              ( "" , [ "accordion-item" ] , [] )
+              [ RawBlock
+                  (Format "html")
+                  "<button class=\"accordion-button instructor-button collapsed\" type=\"button\" data-bs-toggle=\"collapse\" data-bs-target=\"#collapseInstructor1\" aria-expanded=\"false\" aria-controls=\"collapseInstructor1\">\n  <h3 class=\"accordion-header\" id=\"headingInstructor1\">\n  <div class=\"note-square\"><i aria-hidden=\"true\" class=\"callout-icon\" data-feather=\"edit-2\"></i></div>\n  Instructor Note\n  </h3>\n</button>"
+              , Div
+                  ( "collapseInstructor1"
+                  , [ "accordion-collapse" , "collapse" ]
+                  , [ ( "[instructor collapse]" )
+                    , ( "[instructor collapse]" )
+                    ]
+                  )
+                  [ Div
+                      ( "" , [ "accordion-body" ] , [] )
+                      [ Para
+                          [ Str "This"
+                          , Space
+                          , Str "should"
+                          , Space
+                          , Str "be"
+                          , Space
+                          , Str "aside"
+                          ]
+                      ]
+                  ]
+              ]
+          ]
+      , Div
+          ( "" , [ "nothing" ] , [] )
+          [ Para
+              [ Str "This" , Space , Str "should" , Space , Str "be" ]
+          ]
+      ]
 
 # paragraphs after objectives block are parsed correctly
 
     Code
       cat(readLines(out), sep = "\n")
     Output
-      [RawBlock (Format "text") ""
-      ,Div ("",["overview","card"],[])
-       [RawBlock (Format "html") "<h2 class='card-header'>Overview</h2>"
-       ,Div ("",["row","g-0"],[])
-        [Div ("",["col-md-4"],[])
-         [Div ("",["card-body"],[])
-          [Div ("",["inner"],[])
-           [RawBlock (Format "html") "<h3 class='card-title'>Questions</h3>"
-           ,BulletList
-            [[Plain [Str "What\8217s",Space,Str "the",Space,Str "point?"]]]]]]
-        ,Div ("",["col-md-8"],[])
-         [Div ("",["card-body"],[])
-          [Div ("",["inner","bordered"],[])
-           [RawBlock (Format "html") "<h3 class='card-title'>Objectives</h3>"
-           ,BulletList
-            [[Plain [Str "Bake",Space,Str "him",Space,Str "away,",Space,Str "toys"]]]]]]]]
-      ,Para [Str "Do",Space,Str "you",Space,Str "think",Space,Str "he",Space,Str "saurus?"]
-      ,Header 1 ("markdown",[],[]) [Str "Markdown"]]
+      [ RawBlock (Format "text") ""
+      , Div
+          ( "" , [ "overview" , "card" ] , [] )
+          [ RawBlock
+              (Format "html") "<h2 class='card-header'>Overview</h2>"
+          , Div
+              ( "" , [ "row" , "g-0" ] , [] )
+              [ Div
+                  ( "" , [ "col-md-4" ] , [] )
+                  [ Div
+                      ( "" , [ "card-body" ] , [] )
+                      [ Div
+                          ( "" , [ "inner" ] , [] )
+                          [ RawBlock
+                              (Format "html")
+                              "<h3 class='card-title'>Questions</h3>"
+                          , BulletList
+                              [ [ Plain
+                                    [ Str "What\8217s"
+                                    , Space
+                                    , Str "the"
+                                    , Space
+                                    , Str "point?"
+                                    ]
+                                ]
+                              ]
+                          ]
+                      ]
+                  ]
+              , Div
+                  ( "" , [ "col-md-8" ] , [] )
+                  [ Div
+                      ( "" , [ "card-body" ] , [] )
+                      [ Div
+                          ( "" , [ "inner" , "bordered" ] , [] )
+                          [ RawBlock
+                              (Format "html")
+                              "<h3 class='card-title'>Objectives</h3>"
+                          , BulletList
+                              [ [ Plain
+                                    [ Str "Bake"
+                                    , Space
+                                    , Str "him"
+                                    , Space
+                                    , Str "away,"
+                                    , Space
+                                    , Str "toys"
+                                    ]
+                                ]
+                              ]
+                          ]
+                      ]
+                  ]
+              ]
+          ]
+      , Para
+          [ Str "Do"
+          , Space
+          , Str "you"
+          , Space
+          , Str "think"
+          , Space
+          , Str "he"
+          , Space
+          , Str "saurus?"
+          ]
+      , Header 1 ( "markdown" , [] , [] ) [ Str "Markdown" ]
+      ]
 
 # render_html applies the internal lua filter
 
@@ -113,16 +344,20 @@
       <p>How do you write markdown divs?</p>
       <p>This <a href="Setup.html">link should be transformed</a></p>
       <p>This <a href="01-Introduction.html">rmd link also</a></p>
-      <p>This <a href="https://example.com/01-Introduction.Rmd" class="newclass">rmd is safe</a></p>
-      <p>This <a href="Setup.html#windows-setup" title="windows setup">too</a></p>
+      <p>This <a href="https://example.com/01-Introduction.Rmd"
+      class="newclass">rmd is safe</a></p>
+      <p>This <a href="Setup.html#windows-setup"
+      title="windows setup">too</a></p>
       <div class="figure">
-      <img src="fig/Setup.png" id="fig-first" class="imgclass" alt="alt text" alt="" />
+      <img src="fig/Setup.png" id="fig-first" class="imgclass"
+      alt="alt text" />
       <p class="caption">link should be transformed</p>
       </div>
       </div>
       </div>
       </div>
-      <div id="accordionSolution1" class="accordion challenge-accordion accordion-flush">
+      <div id="accordionSolution1"
+      class="accordion challenge-accordion accordion-flush">
       <div class="accordion-item">
       <button class="accordion-button solution-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSolution1" aria-expanded="false" aria-controls="collapseSolution1">
         <h4 class="accordion-header" id="headingSolution1">
@@ -130,13 +365,15 @@
         </h4>
       </button>
       [solution collapse]
+      [solution collapse]
       <div class="accordion-body">
       <p>just write it, silly.</p>
       </div>
       </div>
       </div>
       </div>
-      <div id="accordionInstructor1" class="accordion instructor-note accordion-flush">
+      <div id="accordionInstructor1"
+      class="accordion instructor-note accordion-flush">
       <div class="accordion-item">
       <button class="accordion-button instructor-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseInstructor1" aria-expanded="false" aria-controls="collapseInstructor1">
         <h3 class="accordion-header" id="headingInstructor1">
@@ -144,6 +381,8 @@
         Instructor Note
         </h3>
       </button>
+      [instructor collapse]
+      [instructor collapse]
       [instructor collapse]
       <div class="accordion-body">
       <p>This should be aside</p>

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -89,8 +89,8 @@ test_that("pandoc structure is rendered correctly", {
   }
   skip_on_os("windows")
   formation = function(x) {
-    x <- sub("[,]Div [(]\"collapseInstructor1\".+", "[instructor collapse]", x)
-    sub("[,]Div [(]\"collapseSolution1\".+", "[solution collapse]", x)
+    x <- sub("(data-bs-parent|aria-labelledby).+?Instructor1", "[instructor collapse]", x)
+    sub("(data-bs-parent|aria-labelledby).+?Solution1", "[solution collapse]", x)
   }
   expect_snapshot(cat(readLines(out), sep = "\n"), transform = formation)
 })
@@ -148,7 +148,9 @@ test_that("render_html applies the internal lua filter", {
   skip_on_os("windows")
   formation = function(x) {
     x <- sub("[<]div id[=]\"collapseSolution1\".+", "[solution collapse]", x)
-    sub("[<]div id[=]\"collapseInstructor1\".+", "[instructor collapse]", x)
+    x <- sub("[<]div id[=]\"collapseInstructor1\".+", "[instructor collapse]", x)
+    x <- sub("(data-bs-parent|aria-labelledby).+?Instructor1.+$", "[instructor collapse]", x)
+    sub("(data-bs-parent|aria-labelledby).+?Solution1.+$", "[solution collapse]", x)
 
   }
   expect_snapshot(cat(res), transform = formation)


### PR DESCRIPTION
This sets the default pandoc for testing to 2.19.2 and updates the snaps

To use this version of pandoc before testing, you should run `pandoc::pandoc_activate("2.19.2")`. It will download and install that version of pandoc to your application directory (this will differ depending on the system, you can use `pandoc::pandoc_bin()` to find it).

I have put the path to this folder in my `.bashrc` so that I always default to using pandoc 2.19.2:


```bash
# SET PANDOC VERSION
if [ -d "/home/zhian/.local/share/r-pandoc/2.19.2" ]; then
    export PATH="/home/zhian/.local/share/r-pandoc/2.19.2:$PATH"
fi

```