### PR TITLE
fix discuss list link

### DIFF
--- a/inst/templates/contributing-template.txt
+++ b/inst/templates/contributing-template.txt
@@ -107,7 +107,7 @@ email][contact].
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
 [dc-lessons]: https://datacarpentry.org/lessons/
 [dc-site]: https://datacarpentry.org/
-[discuss-list]: https://lists.software-carpentry.org/listinfo/discuss
+[discuss-list]: https://carpentries.topicbox.com/groups/discuss
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join


### PR DESCRIPTION
This fixes the link for the discuss list, which was sorely out of date