### PR TITLE
Test fix for renv 1.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
   version comparisons always use characters and not numbers (which is
   ergonomically weird, but whatever) (reported: @zkamvar #487; fixed: @zkamvar
   #487)
+* Tests for {renv} post 1.0.0 fixed so that they no longer run forever
+  interactively (reported: @zkamvar #500; fixed: @zkamvar, #501)
 
 # sandpaper 0.12.4 (2023-06-16)
 

--- a/R/utils-renv.R
+++ b/R/utils-renv.R
@@ -79,7 +79,10 @@ try_use_renv <- function(force = FALSE) {
     callr::r(function(ok) {
       options("renv.consent" = ok)
       renv::consent(provided = ok)
-    }, args = list(ok = force), stdout = tmp)
+    }, args = list(ok = force),
+      stdout = tmp,
+    env = c(callr::rcmd_safe_env(),
+      "RENV_VERBOSE" = "TRUE"))
   }, error = function(e) FALSE)
   options(sandpaper.use_renv = x)
   lines <- readLines(tmp)

--- a/R/utils-renv.R
+++ b/R/utils-renv.R
@@ -269,7 +269,7 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
     }
     #nocov end
     hydra <- renv::hydrate(packages = pkgs, library = renv_lib, update = FALSE,
-      sources = .libPaths(), project = path)
+      sources = .libPaths(), project = path, prompt = FALSE)
     #nocov start
     # NOTE: I am not testing this now because this code requires yet another
     # step to install packages. I will rely on the integration tests to help

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -6,6 +6,11 @@
   rmt <- fs::file_temp(pattern = "REMOTE-")
   setup_local_remote(repo = tmp, remote = rmt, verbose = FALSE)
 
+  no_gh_token <- !nzchar(Sys.getenv("GITHUB_PAT"))
+  if (no_gh_token && requireNamespace("gh", quietly = TRUE)) {
+    Sys.setenv("GITHUB_PAT" = gh::gh_token())
+    withr::defer(Sys.unsetenv("GITHUB_PAT"), teardown_env())
+  }
   noise <- interactive() || Sys.getenv("CI") == "true"
   if (noise) {
     cli::cli_alert_info("Current RENV_PATHS_ROOT {Sys.getenv('RENV_PATHS_ROOT')}")

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -16,14 +16,16 @@ test_that("use_package_cache() will report consent implied if renv cache is pres
   withr::local_options(list(sandpaper.use_renv = FALSE))
   expect_false(getOption("sandpaper.use_renv"))
 
-  expect_message(
-    use_package_cache(prompt = TRUE, quiet = FALSE),
-    "Consent for renv provided---consent for package cache implied."
-  )
-  expect_message(
-    use_package_cache(prompt = TRUE, quiet = FALSE),
-    "Consent to use package cache provided"
-  )
+  use_package_cache(prompt = FALSE, quiet = TRUE)
+  expect_true(getOption("sandpaper.use_renv"))
+
+  # a consent message is printed
+  suppressMessages({
+    expect_message(
+      use_package_cache(prompt = TRUE, quiet = FALSE),
+      "Consent to use package cache provided"
+    )
+  })
   expect_true(getOption("sandpaper.use_renv"))
 
 })

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -58,7 +58,7 @@ test_that("manage_deps() will create a renv folder", {
 
   # NOTE: these tests are still not very specific here...
   suppressMessages({
-    build_markdown(lsn, quiet = FALSE) %>%
+    capture.output(build_markdown(lsn, quiet = FALSE)) %>%
       expect_message("Consent to use package cache provided")
   })
 

--- a/tests/testthat/test-manage_deps.R
+++ b/tests/testthat/test-manage_deps.R
@@ -83,6 +83,9 @@ test_that("manage_deps() will run without callr", {
     "RENV_CONFIG_CACHE_SYMLINKS" = renv_cache_available()
   ))
 
+  # 2023-08-21
+  # I found a slowdown here when running this interactively, which was
+  # fixed by setting `prompt = FALSE` when we were testing in `renv::hydrate`
   suppressMessages({
   callr_manage_deps(lsn,
     repos = renv_carpentries_repos(),


### PR DESCRIPTION
This adds test fixes for renv 1.0.2

This will also fix #500 by setting `prompt = FALSE` in the call to `renv::hydrate()` during interactive testing.

Because this is a Developer QOL test, I will merge this without review. 