### PR TITLE
fix aggregate functions to not fail with special episode names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.13.1 (unreleased)
+
+* Aggregate pages will no longer fail if an episode has a prefix that is the
+  same as that aggregate page (e.g. `images.html` will no longer fail if there
+  is an episode that starts with `images-`) (reported: @mwhamgenomics, #511;
+  fixed: @zkamvar, #512)
+
 # sandpaper 0.13.0 (2023-09-06)
 
 ## NEW FEATURES

--- a/R/build_aio.R
+++ b/R/build_aio.R
@@ -12,7 +12,7 @@ build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
 #'
 #' @param name the name of the section, prefixed with `episode-`
 #' @param contents the episode contents from [get_content()]
-#' @param parent the parent div of the AiO page. 
+#' @param parent the parent div of the AiO page.
 #' @return the section that was added to the parent
 #'
 #' @keywords internal
@@ -21,15 +21,16 @@ build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
 #' if (FALSE) {
 #' lsn <- "/path/to/lesson"
 #' pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
-#' 
+#'
 #' # read in the All in One page and extract its content
 #' aio <- get_content("aio", content = "self::*", pkg = pkg)
 #' episode_content <- get_content("01-introduction", pkg = pkg)
-#' make_aio_section("aio-01-introduction", 
+#' make_aio_section("aio-01-introduction",
 #'   contents = episode_content, parent = aio)
 #' }
 make_aio_section <- function(name, contents, parent) {
-  uri <- sub("aio-", "", name)
+  # trimm off the aio because we know it's a prefix
+  uri <- sub("^aio-", "", name)
   title <- escape_ampersand(xml2::xml_text(contents[[1]]))
   new_section <- "<section id='{name}'><p>Content from <a href='{uri}.html'>{title}</a></p><hr/></section>"
   section <- xml2::read_xml(glue::glue(new_section))

--- a/R/build_aio.R
+++ b/R/build_aio.R
@@ -1,7 +1,9 @@
 #' @rdname build_agg
 build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
-  build_agg_page(pkg = pkg, pages = pages, title = "All in One View",
-    slug = "aio", aggregate = "*", prefix = TRUE, quiet = quiet)
+  build_agg_page(
+    pkg = pkg, pages = pages, title = "All in One View",
+    slug = "aio", aggregate = "*", prefix = TRUE, quiet = quiet
+  )
 }
 
 
@@ -19,14 +21,15 @@ build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
 #' @seealso [build_aio()], [get_content()]
 #' @examples
 #' if (FALSE) {
-#' lsn <- "/path/to/lesson"
-#' pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'   lsn <- "/path/to/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 #'
-#' # read in the All in One page and extract its content
-#' aio <- get_content("aio", content = "self::*", pkg = pkg)
-#' episode_content <- get_content("01-introduction", pkg = pkg)
-#' make_aio_section("aio-01-introduction",
-#'   contents = episode_content, parent = aio)
+#'   # read in the All in One page and extract its content
+#'   aio <- get_content("aio", content = "self::*", pkg = pkg)
+#'   episode_content <- get_content("01-introduction", pkg = pkg)
+#'   make_aio_section("aio-01-introduction",
+#'     contents = episode_content, parent = aio
+#'   )
 #' }
 make_aio_section <- function(name, contents, parent) {
   # trimm off the aio because we know it's a prefix
@@ -57,7 +60,7 @@ section_contents <- function(section) {
 
 update_section <- function(section, new) {
   to_clean <- section_contents(section)
-  info     <- xml2::xml_find_first(section, "./hr")
+  info <- xml2::xml_find_first(section, "./hr")
   xml2::xml_remove(to_clean)
   for (node in rev(new)) {
     xml2::xml_add_sibling(info, node, .where = "after")
@@ -70,5 +73,4 @@ get_title <- function(doc) {
 }
 
 # nocov end
-
 

--- a/R/build_aio.R
+++ b/R/build_aio.R
@@ -1,8 +1,13 @@
 #' @rdname build_agg
 build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
   build_agg_page(
-    pkg = pkg, pages = pages, title = "All in One View",
-    slug = "aio", aggregate = "*", prefix = TRUE, quiet = quiet
+    pkg = pkg,
+    pages = pages,
+    title = "All in One View",
+    slug = "aio",
+    aggregate = "*",
+    prefix = TRUE,
+    quiet = quiet
   )
 }
 
@@ -32,7 +37,7 @@ build_aio <- function(pkg, pages = NULL, quiet = FALSE) {
 #'   )
 #' }
 make_aio_section <- function(name, contents, parent) {
-  # trimm off the aio because we know it's a prefix
+  # trim off the aio because we know it's a prefix
   uri <- sub("^aio-", "", name)
   title <- escape_ampersand(xml2::xml_text(contents[[1]]))
   new_section <- "<section id='{name}'><p>Content from <a href='{uri}.html'>{title}</a></p><hr/></section>"

--- a/R/build_images.R
+++ b/R/build_images.R
@@ -33,7 +33,8 @@ build_images <- function(pkg, pages = NULL, quiet = FALSE) {
 #' }
 make_images_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
-  uri <- sub("^images-", "", name)
+  print(name)
+  uri <- name
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>

--- a/R/build_images.R
+++ b/R/build_images.R
@@ -35,7 +35,6 @@ build_images <- function(pkg, pages = NULL, quiet = FALSE) {
 #' }
 make_images_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
-  print(name)
   uri <- name
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>

--- a/R/build_images.R
+++ b/R/build_images.R
@@ -1,12 +1,14 @@
 #' @rdname build_agg
 build_images <- function(pkg, pages = NULL, quiet = FALSE) {
-  build_agg_page(pkg = pkg,
+  build_agg_page(
+    pkg = pkg,
     pages = pages,
     title = "All Images",
     slug = "images",
     aggregate = "/img/..",
     prefix = FALSE,
-    quiet = quiet)
+    quiet = quiet
+  )
 }
 
 #' Make a section of aggregated images
@@ -23,13 +25,13 @@ build_images <- function(pkg, pages = NULL, quiet = FALSE) {
 #' @seealso [build_images()], [get_content()]
 #' @examples
 #' if (FALSE) {
-#' lsn <- "/path/to/lesson"
-#' pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'   lsn <- "/path/to/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 #'
-#' # read in the All in One page and extract its content
-#' img <- get_content("images", content = "self::*", pkg = pkg)
-#' fig_content <- get_content("01-introduction", content = "/figure", pkg = pkg)
-#' make_images_section("01-introduction", contents = fig_content, parent = img)
+#'   # read in the All in One page and extract its content
+#'   img <- get_content("images", content = "self::*", pkg = pkg)
+#'   fig_content <- get_content("01-introduction", content = "/figure", pkg = pkg)
+#'   make_images_section("01-introduction", contents = fig_content, parent = img)
 #' }
 make_images_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
@@ -43,10 +45,11 @@ make_images_section <- function(name, contents, parent) {
 
   for (element in seq_along(contents)) {
     content <- contents[[element]]
-    alt     <- xml2::xml_text(xml2::xml_find_all(content, "./img/@alt"))
+    alt <- xml2::xml_text(xml2::xml_find_all(content, "./img/@alt"))
     n <- length(alt)
     xml2::xml_add_child(section, "h3", glue::glue("Figure {element}"),
-      id = glue::glue("{name}-figure-{element}"))
+      id = glue::glue("{name}-figure-{element}")
+    )
     for (i in seq_along(alt)) {
       txt <- alt[[i]]
       if (length(txt) == 0) {
@@ -56,10 +59,11 @@ make_images_section <- function(name, contents, parent) {
         txt <- "[decorative]"
       }
       desc <- glue::glue("Image {i} of {n}: {sQuote(txt)}")
-      xml2::xml_add_child(section, "p", 'aria-hidden'="true", desc)
+      xml2::xml_add_child(section, "p", "aria-hidden" = "true", desc)
     }
     xml2::xml_add_child(section, contents[[element]])
     xml2::xml_add_child(section, "hr")
   }
   xml2::xml_add_child(parent, section)
 }
+

--- a/R/build_instructor_notes.R
+++ b/R/build_instructor_notes.R
@@ -14,8 +14,8 @@ build_instructor_notes <- function(pkg, pages = NULL, built = NULL, quiet) {
     inote <- .resources$get()[["instructors"]]
     inote <- inote[get_slug(inote) == "instructor-notes"]
     html <- render_html(inote)
-    if (html != '') {
-      html  <- xml2::read_html(html)
+    if (html != "") {
+      html <- xml2::read_html(html)
       fix_nodes(html)
     } else {
       html <- xml2::read_html("<p></p>")
@@ -29,13 +29,15 @@ build_instructor_notes <- function(pkg, pages = NULL, built = NULL, quiet) {
 
     page_globals$instructor$update(this_dat)
 
-    this_dat$body = use_learner(html)
+    this_dat$body <- use_learner(html)
     page_globals$learner$update(this_dat)
 
     page_globals$meta$update(this_dat)
 
-    build_html(template = "extra", pkg = pkg, nodes = html,
-      global_data = page_globals, path_md = "instructor-notes.html", quiet = TRUE)
+    build_html(
+      template = "extra", pkg = pkg, nodes = html,
+      global_data = page_globals, path_md = "instructor-notes.html", quiet = TRUE
+    )
   }
   # shortcut if we don't have any episodes
   is_overview <- lsn$overview && length(lsn$episodes) == 0
@@ -43,14 +45,16 @@ build_instructor_notes <- function(pkg, pages = NULL, built = NULL, quiet) {
     return(invisible(NULL))
   }
   agg <- "/div[contains(@class, 'instructor-note')]//*[@class='accordion-body' or @class='accordion-header']"
-  build_agg_page(pkg = pkg,
+  build_agg_page(
+    pkg = pkg,
     pages = pages,
     title = this_dat$pagetitle,
     slug = "instructor-notes",
     aggregate = agg,
     append = "section[@id='aggregate-instructor-notes']",
     prefix = FALSE,
-    quiet = quiet)
+    quiet = quiet
+  )
 }
 
 #' Make a section of aggregated instructor notes
@@ -68,23 +72,28 @@ build_instructor_notes <- function(pkg, pages = NULL, built = NULL, quiet) {
 #' @seealso [build_instructor_notes()], [get_content()]
 #' @examples
 #' if (FALSE) {
-#' lsn <- "/path/to/lesson"
-#' pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'   lsn <- "/path/to/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 #'
-#' # read in the All in One page and extract its content
-#' notes <- get_content("instructor-notes", content =
-#'   "section[@id='aggregate-instructor-notes']", pkg = pkg, instructor = TRUE)
-#' agg <- "/div[contains(@class, 'instructor-note')]//div[@class='accordion-body']"
-#' note_content <- get_content("01-introduction", content = agg, pkg = pkg)
-#' make_instructornotes_section("01-introduction", contents = note_content,
-#'   parent = notes)
+#'   # read in the All in One page and extract its content
+#'   notes <- get_content("instructor-notes",
+#'     content =
+#'       "section[@id='aggregate-instructor-notes']", pkg = pkg, instructor = TRUE
+#'   )
+#'   agg <- "/div[contains(@class, 'instructor-note')]//div[@class='accordion-body']"
+#'   note_content <- get_content("01-introduction", content = agg, pkg = pkg)
+#'   make_instructornotes_section("01-introduction",
+#'     contents = note_content,
+#'     parent = notes
+#'   )
 #'
-#' # NOTE: if the object for "contents" ends with "_learn", no content will be
-#' # appended
-#' note_learn <- note_content
-#' make_instructornotes_section("01-introduction", contents = note_learn,
-#'   parent = notes)
-#'
+#'   # NOTE: if the object for "contents" ends with "_learn", no content will be
+#'   # appended
+#'   note_learn <- note_content
+#'   make_instructornotes_section("01-introduction",
+#'     contents = note_learn,
+#'     parent = notes
+#'   )
 #' }
 make_instructornotes_section <- function(name, contents, parent) {
   # Since we have hidden the instructor notes from the learner sections,
@@ -95,14 +104,14 @@ make_instructornotes_section <- function(name, contents, parent) {
     return(invisible(NULL))
   }
   title <- names(name)
-  uri <- name #sub("^instructor-notes-", "", name)
+  uri <- name # sub("^instructor-notes-", "", name)
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>
   </section>"
   section <- xml2::read_xml(glue::glue(new_section))
   for (element in contents) {
-    is_heading  <- xml2::xml_name(element) == "h3" &
+    is_heading <- xml2::xml_name(element) == "h3" &
       xml2::xml_attr(element, "class") == "accordion-header"
     if (is_heading) {
       # when we have an instructor note heading, we need to just add it and
@@ -132,3 +141,4 @@ make_instructor_note_linkback <- function(node, name) {
   xml2::xml_set_attr(node, "id", newid)
   node
 }
+

--- a/R/build_instructor_notes.R
+++ b/R/build_instructor_notes.R
@@ -95,7 +95,7 @@ make_instructornotes_section <- function(name, contents, parent) {
     return(invisible(NULL))
   }
   title <- names(name)
-  uri <- sub("^instructor-notes-", "", name)
+  uri <- name #sub("^instructor-notes-", "", name)
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>

--- a/R/build_instructor_notes.R
+++ b/R/build_instructor_notes.R
@@ -104,7 +104,7 @@ make_instructornotes_section <- function(name, contents, parent) {
     return(invisible(NULL))
   }
   title <- names(name)
-  uri <- name # sub("^instructor-notes-", "", name)
+  uri <- name
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>

--- a/R/build_keypoints.R
+++ b/R/build_keypoints.R
@@ -1,17 +1,19 @@
 #' @rdname build_agg
 build_keypoints <- function(pkg, pages = NULL, quiet = FALSE) {
-  build_agg_page(pkg = pkg,
+  build_agg_page(
+    pkg = pkg,
     pages = pages,
     title = "Key Points",
     slug = "key-points",
     aggregate = "/div[starts-with(@id, 'keypoints')]/div[@class='callout-inner']/div[@class='callout-content']/*",
     prefix = FALSE,
-    quiet = quiet)
+    quiet = quiet
+  )
 }
 
 make_keypoints_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
-  uri <- name #sub("^keypoints-", "", name)
+  uri <- name # sub("^keypoints-", "", name)
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>
@@ -22,3 +24,4 @@ make_keypoints_section <- function(name, contents, parent) {
   }
   xml2::xml_add_child(parent, section)
 }
+

--- a/R/build_keypoints.R
+++ b/R/build_keypoints.R
@@ -13,7 +13,7 @@ build_keypoints <- function(pkg, pages = NULL, quiet = FALSE) {
 
 make_keypoints_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
-  uri <- name # sub("^keypoints-", "", name)
+  uri <- name
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>

--- a/R/build_keypoints.R
+++ b/R/build_keypoints.R
@@ -1,17 +1,17 @@
 #' @rdname build_agg
 build_keypoints <- function(pkg, pages = NULL, quiet = FALSE) {
-  build_agg_page(pkg = pkg, 
-    pages = pages, 
-    title = "Key Points", 
-    slug = "key-points", 
-    aggregate = "/div[starts-with(@id, 'keypoints')]/div[@class='callout-inner']/div[@class='callout-content']/*", 
-    prefix = FALSE, 
+  build_agg_page(pkg = pkg,
+    pages = pages,
+    title = "Key Points",
+    slug = "key-points",
+    aggregate = "/div[starts-with(@id, 'keypoints')]/div[@class='callout-inner']/div[@class='callout-content']/*",
+    prefix = FALSE,
     quiet = quiet)
 }
 
 make_keypoints_section <- function(name, contents, parent) {
   title <- escape_ampersand(names(name))
-  uri <- sub("^keypoints-", "", name)
+  uri <- name #sub("^keypoints-", "", name)
   new_section <- "<section id='{name}'>
   <h2 class='section-heading'><a href='{uri}.html'>{title}</a></h2>
   <hr class='half-width'/>

--- a/R/serve.R
+++ b/R/serve.R
@@ -45,24 +45,24 @@
 #' @seealso [build_lesson()], render the lesson once, locally.
 #' @examples
 #' if (FALSE) {
-#'  # create an example lesson
-#'  tmp <- tempfile()
-#'  create_lesson(tmp, open = FALSE)
+#'   # create an example lesson
+#'   tmp <- tempfile()
+#'   create_lesson(tmp, open = FALSE)
 #'
-#'  # open the episode for editing
-#'  file.edit(fs::path(tmp, "episodes", "01-introduction.Rmd"))
+#'   # open the episode for editing
+#'   file.edit(fs::path(tmp, "episodes", "01-introduction.Rmd"))
 #'
-#'  # serve the lesson and begin editing the file. Watch how the file will
-#'  # auto-update whenever you save it.
-#'  sandpaper::serve()
-#'  #
-#'  # to stop the server, run
-#'  servr::daemon_stop()
-#'  #
-#'  # If you want to use a different port, you can specify it directly
-#'  sandpaper::serve(host = "127.0.0.1", port = "3435")
+#'   # serve the lesson and begin editing the file. Watch how the file will
+#'   # auto-update whenever you save it.
+#'   sandpaper::serve()
+#'   #
+#'   # to stop the server, run
+#'   servr::daemon_stop()
+#'   #
+#'   # If you want to use a different port, you can specify it directly
+#'   sandpaper::serve(host = "127.0.0.1", port = "3435")
 #' }
-#nocov start
+# nocov start
 # Note: we can not test this in covr because I'm not entirely sure of how to get
 #       it going
 serve <- function(path = ".", quiet = !interactive(), ...) {
@@ -76,7 +76,7 @@ serve <- function(path = ".", quiet = !interactive(), ...) {
     }
     for (f in file_list) {
       if (!quiet) {
-        cli::cli_alert_info("Rebuilding {.path f}")
+        cli::cli_alert_info("Rebuilding {.path {f}}")
       }
       build_lesson(f, preview = FALSE, quiet = quiet)
     }
@@ -92,7 +92,7 @@ serve <- function(path = ".", quiet = !interactive(), ...) {
   # @param base the base path
   make_filter <- function(base = this_path) {
     no_site <- file.path(base, "site")
-    no_git  <- file.path(base, ".git")
+    no_git <- file.path(base, ".git")
     # return a filter function for the files
     function(x) {
       return(x[(!startsWith(x, no_site) | !startsWith(x, no_git))])
@@ -101,7 +101,10 @@ serve <- function(path = ".", quiet = !interactive(), ...) {
   this_filter <- make_filter(this_path)
   # to start, build the site and then watch things:
   rend(this_path)
-  servr::httw(prod, watch = this_path, filter = this_filter, handler = rend,
-    ...)
+  servr::httw(prod,
+    watch = this_path, filter = this_filter, handler = rend,
+    ...
+  )
 }
-#nocov end
+# nocov end
+

--- a/R/utils-aggregate.R
+++ b/R/utils-aggregate.R
@@ -246,7 +246,7 @@ build_agg_page <- function(pkg, pages, title = NULL, slug = NULL, aggregate = "s
     ep_learn <- ep_instruct <- the_episodes[episode]
     ename    <- the_slugs[episode]
     if (!is.null(pages)) {
-      name <- sub(paste0("^", slug, "-"), "", ename)
+      name <- if (prefix) sub(paste0("^", slug, "-"), "", ename) else ename
       ep_learn <- pages$learner[[name]]
       ep_instruct <- pages$instructor[[name]]
     }

--- a/R/utils-aggregate.R
+++ b/R/utils-aggregate.R
@@ -87,12 +87,11 @@ read_all_html <- function(path) {
 #' @rdname provision
 #' @examples
 #' if (FALSE) { # only run if you have provisioned a pkgdown site
-#' lsn_site <- "/path/to/lesson/site"
-#' pkg <- pkgdown::as_pkgdown(lsn_site)
+#'   lsn_site <- "/path/to/lesson/site"
+#'   pkg <- pkgdown::as_pkgdown(lsn_site)
 #'
-#' # create an AIO page
-#' provision_agg_page(pkg, title = "All In One", slug = "aio", quiet = FALSE)
-#'
+#'   # create an AIO page
+#'   provision_agg_page(pkg, title = "All In One", slug = "aio", quiet = FALSE)
 #' }
 provision_agg_page <- function(pkg, title = "Key Points", slug = "key-points", new = FALSE) {
   if (new) {
@@ -111,10 +110,11 @@ provision_agg_page <- function(pkg, title = "Key Points", slug = "key-points", n
     instructor <- fs::path(pkg$dst_path, "instructor", uri)
   }
 
-  return(list(learner = xml2::read_html(learner),
+  return(list(
+    learner = xml2::read_html(learner),
     instructor = xml2::read_html(instructor),
-    needs_episodes = new)
-  )
+    needs_episodes = new
+  ))
 }
 
 #' @keywords internal
@@ -139,16 +139,22 @@ provision_extra_template <- function(pkg, quiet = TRUE) {
   page_globals$learner$update(this_dat)
   page_globals$metadata$update(c(this_dat, list(date = list(modified = date))))
 
-  build_html(template = "extra", pkg = pkg, nodes = html,
-    global_data = page_globals, path_md = page, quiet = quiet)
+  build_html(
+    template = "extra", pkg = pkg, nodes = html,
+    global_data = page_globals, path_md = page, quiet = quiet
+  )
   on.exit({
     fs::file_delete(learner)
     fs::file_delete(instructor)
   })
-  .html$set(c("template", "extra", "learner"),
-    as.character(xml2::read_html(learner)))
-  .html$set(c("template", "extra", "instructor"),
-    as.character(xml2::read_html(instructor)))
+  .html$set(
+    c("template", "extra", "learner"),
+    as.character(xml2::read_html(learner))
+  )
+  .html$set(
+    c("template", "extra", "instructor"),
+    as.character(xml2::read_html(instructor))
+  )
 }
 
 section_fun <- function(slug) {
@@ -244,7 +250,7 @@ build_agg_page <- function(pkg, pages, title = NULL, slug = NULL, aggregate = "s
 
   for (episode in seq(the_episodes)) {
     ep_learn <- ep_instruct <- the_episodes[episode]
-    ename    <- the_slugs[episode]
+    ename <- the_slugs[episode]
     if (!is.null(pages)) {
       name <- if (prefix) sub(paste0("^", slug, "-"), "", ename) else ename
       ep_learn <- pages$learner[[name]]
@@ -298,26 +304,25 @@ build_agg_page <- function(pkg, pages, title = NULL, slug = NULL, aggregate = "s
 #' @keywords internal
 #' @examples
 #' if (FALSE) {
-#' lsn <- "/path/to/lesson"
-#' pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'   lsn <- "/path/to/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 #'
-#' # for AiO pages, this will return only the top-level sections:
-#' get_content("aio", content = "section", label = TRUE, pkg = pkg)
+#'   # for AiO pages, this will return only the top-level sections:
+#'   get_content("aio", content = "section", label = TRUE, pkg = pkg)
 #'
-#' # for episode pages, this will return everything that's not template
-#' get_content("01-introduction", pkg = pkg)
+#'   # for episode pages, this will return everything that's not template
+#'   get_content("01-introduction", pkg = pkg)
 #'
-#' # for things that are within lessons but we don't know their exact location,
-#' # we can prefix a `/` to double up the slash, which will produce
-#'
+#'   # for things that are within lessons but we don't know their exact location,
+#'   # we can prefix a `/` to double up the slash, which will produce
 #' }
-get_content <- function(episode, content = "*", label = FALSE, pkg = NULL,
-  instructor = FALSE) {
+get_content <- function(
+    episode, content = "*", label = FALSE, pkg = NULL,
+    instructor = FALSE) {
   if (!inherits(episode, "xml_document")) {
     if (instructor) {
       path <- fs::path(pkg$dst_path, "instructor", as_html(episode))
-    }
-    else {
+    } else {
       path <- fs::path(pkg$dst_path, as_html(episode))
     }
     episode <- xml2::read_html(path)
@@ -335,7 +340,7 @@ escape_ampersand <- function(text) {
   gsub("[&](?![#]?[A-Za-z0-9]+?[;])", "&amp;", text, perl = TRUE)
 }
 
-remove_fix_node <- function(html, id='FIXME') {
+remove_fix_node <- function(html, id = "FIXME") {
   fix_node <- xml2::xml_find_first(html, paste0(".//section[@id='", id, "']"))
   xml2::xml_remove(fix_node)
   return(html)
@@ -360,3 +365,4 @@ urls_to_sitemap <- function(urls) {
   }
   doc
 }
+

--- a/man/get_content.Rd
+++ b/man/get_content.Rd
@@ -45,18 +45,17 @@ This function will extract the content from the episode without the templating.
 }
 \examples{
 if (FALSE) {
-lsn <- "/path/to/lesson"
-pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+  lsn <- "/path/to/lesson"
+  pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 
-# for AiO pages, this will return only the top-level sections:
-get_content("aio", content = "section", label = TRUE, pkg = pkg)
+  # for AiO pages, this will return only the top-level sections:
+  get_content("aio", content = "section", label = TRUE, pkg = pkg)
 
-# for episode pages, this will return everything that's not template
-get_content("01-introduction", pkg = pkg)
+  # for episode pages, this will return everything that's not template
+  get_content("01-introduction", pkg = pkg)
 
-# for things that are within lessons but we don't know their exact location,
-# we can prefix a `/` to double up the slash, which will produce
-
+  # for things that are within lessons but we don't know their exact location,
+  # we can prefix a `/` to double up the slash, which will produce
 }
 }
 \keyword{internal}

--- a/man/make_aio_section.Rd
+++ b/man/make_aio_section.Rd
@@ -22,14 +22,15 @@ from the episode contents in its own section inside the All In One page.
 }
 \examples{
 if (FALSE) {
-lsn <- "/path/to/lesson"
-pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+  lsn <- "/path/to/lesson"
+  pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 
-# read in the All in One page and extract its content
-aio <- get_content("aio", content = "self::*", pkg = pkg)
-episode_content <- get_content("01-introduction", pkg = pkg)
-make_aio_section("aio-01-introduction", 
-  contents = episode_content, parent = aio)
+  # read in the All in One page and extract its content
+  aio <- get_content("aio", content = "self::*", pkg = pkg)
+  episode_content <- get_content("01-introduction", pkg = pkg)
+  make_aio_section("aio-01-introduction",
+    contents = episode_content, parent = aio
+  )
 }
 }
 \seealso{

--- a/man/make_images_section.Rd
+++ b/man/make_images_section.Rd
@@ -22,13 +22,13 @@ descriptions for users who are not using screen readers.
 }
 \examples{
 if (FALSE) {
-lsn <- "/path/to/lesson"
-pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+  lsn <- "/path/to/lesson"
+  pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 
-# read in the All in One page and extract its content
-img <- get_content("images", content = "self::*", pkg = pkg)
-fig_content <- get_content("01-introduction", content = "/figure", pkg = pkg)
-make_images_section("01-introduction", contents = fig_content, parent = img)
+  # read in the All in One page and extract its content
+  img <- get_content("images", content = "self::*", pkg = pkg)
+  fig_content <- get_content("01-introduction", content = "/figure", pkg = pkg)
+  make_images_section("01-introduction", contents = fig_content, parent = img)
 }
 }
 \seealso{

--- a/man/make_instructornotes_section.Rd
+++ b/man/make_instructornotes_section.Rd
@@ -25,23 +25,28 @@ On the learner view, instructor notes will not be present
 }
 \examples{
 if (FALSE) {
-lsn <- "/path/to/lesson"
-pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+  lsn <- "/path/to/lesson"
+  pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
 
-# read in the All in One page and extract its content
-notes <- get_content("instructor-notes", content =
-  "section[@id='aggregate-instructor-notes']", pkg = pkg, instructor = TRUE)
-agg <- "/div[contains(@class, 'instructor-note')]//div[@class='accordion-body']"
-note_content <- get_content("01-introduction", content = agg, pkg = pkg)
-make_instructornotes_section("01-introduction", contents = note_content,
-  parent = notes)
+  # read in the All in One page and extract its content
+  notes <- get_content("instructor-notes",
+    content =
+      "section[@id='aggregate-instructor-notes']", pkg = pkg, instructor = TRUE
+  )
+  agg <- "/div[contains(@class, 'instructor-note')]//div[@class='accordion-body']"
+  note_content <- get_content("01-introduction", content = agg, pkg = pkg)
+  make_instructornotes_section("01-introduction",
+    contents = note_content,
+    parent = notes
+  )
 
-# NOTE: if the object for "contents" ends with "_learn", no content will be
-# appended
-note_learn <- note_content
-make_instructornotes_section("01-introduction", contents = note_learn,
-  parent = notes)
-
+  # NOTE: if the object for "contents" ends with "_learn", no content will be
+  # appended
+  note_learn <- note_content
+  make_instructornotes_section("01-introduction",
+    contents = note_learn,
+    parent = notes
+  )
 }
 }
 \seealso{

--- a/man/provision.Rd
+++ b/man/provision.Rd
@@ -70,12 +70,11 @@ values with the appropriate elements, and returns an object created from
 }
 \examples{
 if (FALSE) { # only run if you have provisioned a pkgdown site
-lsn_site <- "/path/to/lesson/site"
-pkg <- pkgdown::as_pkgdown(lsn_site)
+  lsn_site <- "/path/to/lesson/site"
+  pkg <- pkgdown::as_pkgdown(lsn_site)
 
-# create an AIO page
-provision_agg_page(pkg, title = "All In One", slug = "aio", quiet = FALSE)
-
+  # create an AIO page
+  provision_agg_page(pkg, title = "All In One", slug = "aio", quiet = FALSE)
 }
 }
 \keyword{internal}

--- a/man/serve.Rd
+++ b/man/serve.Rd
@@ -52,22 +52,22 @@ host for this function, you can do so using the port and host arguments:
 }
 \examples{
 if (FALSE) {
- # create an example lesson
- tmp <- tempfile()
- create_lesson(tmp, open = FALSE)
+  # create an example lesson
+  tmp <- tempfile()
+  create_lesson(tmp, open = FALSE)
 
- # open the episode for editing
- file.edit(fs::path(tmp, "episodes", "01-introduction.Rmd"))
+  # open the episode for editing
+  file.edit(fs::path(tmp, "episodes", "01-introduction.Rmd"))
 
- # serve the lesson and begin editing the file. Watch how the file will
- # auto-update whenever you save it.
- sandpaper::serve()
- #
- # to stop the server, run
- servr::daemon_stop()
- #
- # If you want to use a different port, you can specify it directly
- sandpaper::serve(host = "127.0.0.1", port = "3435")
+  # serve the lesson and begin editing the file. Watch how the file will
+  # auto-update whenever you save it.
+  sandpaper::serve()
+  #
+  # to stop the server, run
+  servr::daemon_stop()
+  #
+  # If you want to use a different port, you can specify it directly
+  sandpaper::serve(host = "127.0.0.1", port = "3435")
 }
 }
 \seealso{

--- a/tests/testthat/test-utils-aggregate.R
+++ b/tests/testthat/test-utils-aggregate.R
@@ -1,25 +1,126 @@
 test_that("read_all_html returns appropriate files", {
-
   tmpdir <- withr::local_tempdir()
   fs::dir_create(tmpdir)
   fs::dir_create(fs::path(tmpdir, "instructor"))
   writeLines("<p>Instructor</p>", fs::path(tmpdir, "instructor", "index.html"))
   writeLines("<p>Learner</p>", fs::path(tmpdir, "index.html"))
   res <- read_all_html(tmpdir)
-  expect_named(res, c( "instructor", "learner","paths"))
+  expect_named(res, c("instructor", "learner", "paths"))
   expect_length(res$paths, 2L)
   expect_s3_class(res$learner$index, "xml_document")
   expect_s3_class(res$instructor$index, "xml_document")
   expect_equal(xml2::xml_text(res$learner$index), "Learner")
   expect_equal(xml2::xml_text(res$instructor$index), "Instructor")
-
 })
 
 test_that("escape ampersand works as promised", {
-
   expected <- "Hall &amp; Oates"
   expect_equal(escape_ampersand("Hall & Oates"), expected)
-
 })
 
+
+test_that("aggregate pages do not exorcise self-similar slugs", {
+  # see https://github.com/carpentries/sandpaper/issues/511
+  #
+  # If we set up tests with episodes whose names also match the slugs for
+  # the builders, then we can effectively test that they will work as expected
+  # if we query the aggregate pages for links back to the original episodes
+  res <- restore_fixture()
+  withr::local_options(list("sandpaper.use_renv" = FALSE))
+  withr::defer(clear_globals())
+  create_episode_md("images and pixels", path = res, add = TRUE)
+  create_episode_md("keypoints and others", path = res, add = TRUE)
+  create_episode_md("instructor notes and things", path = res, add = TRUE)
+  create_episode_md("aio stands for an information overload", path = res, add = TRUE)
+  eps <- as.character(fs::path_ext_set(get_episodes(res), "html"))
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+  build_lesson(res, quiet = TRUE, preview = FALSE)
+  sitepath <- fs::path(res, "site/docs")
+
+  # build_images() -----------------------------------------------
+  images <- fs::path(sitepath, "images.html")
+  instruct_images <- fs::path(sitepath, "instructor/images.html")
+  expect_true(fs::file_exists(images))
+  expect_true(fs::file_exists(instruct_images))
+  html <- xml2::read_html(images)
+
+  # ensure the section titles work
+  sections <- get_content(html, "section")
+  expect_length(sections, 5L)
+  expect_equal(xml2::xml_attr(sections, "id"), get_slug(eps),
+    label = "images"
+  )
+
+  # ensure the links are cromulent
+  links <- get_content(html, "section/h2/a")
+  expect_length(links, 5L)
+  expect_equal(xml2::xml_attr(links, "href"), eps,
+    label = "images"
+  )
+
+  # build_keypoints() -----------------------------------------------
+  keypoints <- fs::path(sitepath, "key-points.html")
+  instruct_keypoints <- fs::path(sitepath, "instructor/key-points.html")
+  expect_true(fs::file_exists(keypoints))
+  expect_true(fs::file_exists(instruct_keypoints))
+  html <- xml2::read_html(keypoints)
+
+  # ensure the section titles work
+  sections <- get_content(html, "section")
+  expect_length(sections, 5L)
+  expect_equal(xml2::xml_attr(sections, "id"), get_slug(eps),
+    label = "key-points"
+  )
+
+  # ensure the links are cromulent
+  links <- get_content(html, "section/h2/a")
+  expect_length(links, 5L)
+  expect_equal(xml2::xml_attr(links, "href"), eps,
+    label = "key-points"
+  )
+
+  # build_instructor_notes() -----------------------------------------------
+  instructor_notes <- fs::path(sitepath, "instructor-notes.html")
+  instruct_instructor_notes <- fs::path(sitepath, "instructor/instructor-notes.html")
+  expect_true(fs::file_exists(instructor_notes))
+  expect_true(fs::file_exists(instruct_instructor_notes))
+  expect_length(get_content(xml2::read_html(instructor_notes), "section/*"), 0)
+  html <- xml2::read_html(instruct_instructor_notes)
+
+  # ensure the section titles work
+  sections <- get_content(html, "section/*")
+  expect_length(sections, 5L)
+  expect_equal(xml2::xml_attr(sections, "id"), get_slug(eps),
+    label = "instructor-notes"
+  )
+
+  # ensure the links are cromulent
+  links <- get_content(html, "section/section/h2/a")
+  expect_length(links, 5L)
+  expect_equal(xml2::xml_attr(links, "href"), eps,
+    label = "instructor-notes"
+  )
+
+  # build_aio() -----------------------------------------------
+  aio <- fs::path(sitepath, "aio.html")
+  instruct_aio <- fs::path(sitepath, "instructor/aio.html")
+  expect_true(fs::file_exists(aio))
+  expect_true(fs::file_exists(instruct_aio))
+  html <- xml2::read_html(aio)
+
+  # ensure the section titles work
+  sections <- get_content(html, "section")
+  expect_length(sections, 5L)
+  # the AIO sections have slugs
+  expect_equal(xml2::xml_attr(sections, "id"), paste0("aio-", get_slug(eps)),
+    label = "aio"
+  )
+
+  # ensure the links are cromulent
+  links <- get_content(html, "section/p[1]/a")
+  expect_length(links, 5L)
+  expect_equal(xml2::xml_attr(links, "href"), eps,
+    label = "aio"
+  )
+})
 


### PR DESCRIPTION
In short, there was a problem if someone named an episode starting with `images-`, the build would fail (see #511). In addition, even if it _did_ succeed, the link in the page would fail because it would have the `images-` slug trimmed off.

I have done the following actions to fix this:

1. added tests in `tests/testthat/test-utils-aggregate.R`
2. removed slug trimming in the `make_[thing]_section` family of functions
3. added a `prefix = TRUE` catch in the main aggregate function

I also styled these files using `styler`

## Testing

To test this PR, you can install it locally with `remotes::install_github()` or `pak::pkg_install()` and then run the example below. 

```r
pak::pkg_install("carpentries/sandpaper#512")
```

## Example

This PR will fix that issue and a working reprex is demonstrated below:

``` r
tmp <- tempfile()
sandpaper::create_lesson(tmp, rmd = FALSE, open = FALSE)
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...
#> ℹ No schedule set, using Rmd files in 'episodes/' directory.
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...→ To remove this message, define your schedule in 'config.yaml' or use `set_episodes()` to generate it.
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...────────────────────────────────────────────────────────────────────────────────
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...ℹ To save this configuration, use
#> 
#> set_episodes(path = path, order = ep, write = TRUE)
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...✔ First episode created in '/tmp/Rtmp2CZhpv/file17fbe74349550/episodes/introduction.md'
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...ℹ Workflows up-to-date!
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...✔ Lesson successfully created in '/tmp/Rtmp2CZhpv/file17fbe74349550'
#> → Creating Lesson in '/tmp/Rtmp2CZhpv/file17fbe74349550'...
#> /tmp/Rtmp2CZhpv/file17fbe74349550
sandpaper::create_episode_md("images and pixels", path = tmp, add = TRUE)
sandpaper::build_lesson(tmp, quiet = TRUE, preview = FALSE)
fs::dir_tree(tmp, recurse = 2)
#> /tmp/Rtmp2CZhpv/file17fbe74349550
#> ├── CODE_OF_CONDUCT.md
#> ├── CONTRIBUTING.md
#> ├── LICENSE.md
#> ├── README.md
#> ├── config.yaml
#> ├── episodes
#> │   ├── data
#> │   ├── fig
#> │   ├── files
#> │   ├── images-and-pixels.md
#> │   └── introduction.md
#> ├── index.md
#> ├── instructors
#> │   └── instructor-notes.md
#> ├── learners
#> │   ├── reference.md
#> │   └── setup.md
#> ├── links.md
#> ├── profiles
#> │   └── learner-profiles.md
#> └── site
#>     ├── DESCRIPTION
#>     ├── README.md
#>     ├── _pkgdown.yaml
#>     ├── built
#>     │   ├── CODE_OF_CONDUCT.md
#>     │   ├── LICENSE.md
#>     │   ├── config.yaml
#>     │   ├── data
#>     │   ├── fig
#>     │   ├── files
#>     │   ├── images-and-pixels.md
#>     │   ├── index.md
#>     │   ├── instructor-notes.md
#>     │   ├── introduction.md
#>     │   ├── learner-profiles.md
#>     │   ├── links.md
#>     │   ├── md5sum.txt
#>     │   ├── reference.md
#>     │   └── setup.md
#>     └── docs
#>         ├── 404.html
#>         ├── CODE_OF_CONDUCT.html
#>         ├── LICENSE.html
#>         ├── aio.html
#>         ├── android-chrome-192x192.png
#>         ├── android-chrome-512x512.png
#>         ├── apple-touch-icon.png
#>         ├── assets
#>         ├── bootstrap-toc.css
#>         ├── bootstrap-toc.js
#>         ├── config.yaml
#>         ├── data
#>         ├── docsearch.css
#>         ├── docsearch.js
#>         ├── favicon-16x16.png
#>         ├── favicon-32x32.png
#>         ├── favicons
#>         ├── fig
#>         ├── files
#>         ├── images-and-pixels.html
#>         ├── images.html
#>         ├── index.html
#>         ├── instructor
#>         ├── instructor-notes.html
#>         ├── introduction.html
#>         ├── key-points.html
#>         ├── link.svg
#>         ├── md5sum.txt
#>         ├── mstile-150x150.png
#>         ├── pkgdown.css
#>         ├── pkgdown.js
#>         ├── pkgdown.yml
#>         ├── profiles.html
#>         ├── reference.html
#>         ├── safari-pinned-tab.svg
#>         ├── site.webmanifest
#>         └── sitemap.xml
```

<sup>Created on 2023-09-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
This will fix #511 