### PR TITLE
bypass multiple value problem in default branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.13.1
+Version: 0.13.1.9000
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,14 @@
+# sandpaper 0.13.1.90000 (unreleased)
+
+## BUG FIX
+
+* Users with duplicated `init.defaultBranch` declarations in their git config
+  will no longer fail the default branch check (reported: @tesaunders, #516;
+  fixed: @zkamvar, #517)
+
 # sandpaper 0.13.1 (2023-09-19)
+
+## BUG FIX
 
 * Aggregate pages will no longer fail if an episode has a prefix that is the
   same as that aggregate page (e.g. `images.html` will no longer fail if there

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -330,8 +330,21 @@ enforce_main_branch <- function(path) {
 get_default_branch <- function() {
   cfg <- gert::git_config_global()
   default <- cfg$value[cfg$name == "init.defaultbranch"]
-  invalid <- length(default) == 0 || default == "master"
-  if (invalid) "main" else default
+  # See https://github.com/carpentries/sandpaper/issues/516
+  # If the user accidentally has two init.defatulBranch statements in their
+  # global .gitconfig, then we are going to choose the _last_ defined branch.
+  #
+  # The reason why we choose the _last_ defined branch is because this is what
+  # the command line git does (see https://github.com/r-lib/gert/issues/196),
+  # even if it's not what libgit2 does.
+  # 
+  # NOTE: because this deals with global git configs, I do not really have the
+  # capability to run a test here because this test would necessarily need to
+  # modify the user's global git config, which I do _not_ want to do.
+  n_defaults <- length(default)
+  # no default branches can indicate an earlier version of git
+  invalid <- n_defaults == 0 || default[n_default] == "master"
+  if (invalid) "main" else default[n_default]
 }
 
 # This checks if we have set a temporary git user and then unsets it. It will

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -337,14 +337,14 @@ get_default_branch <- function() {
   # The reason why we choose the _last_ defined branch is because this is what
   # the command line git does (see https://github.com/r-lib/gert/issues/196),
   # even if it's not what libgit2 does.
-  # 
+  #
   # NOTE: because this deals with global git configs, I do not really have the
   # capability to run a test here because this test would necessarily need to
   # modify the user's global git config, which I do _not_ want to do.
   n_defaults <- length(default)
   # no default branches can indicate an earlier version of git
-  invalid <- n_defaults == 0 || default[n_default] == "master"
-  if (invalid) "main" else default[n_default]
+  invalid <- n_defaults == 0 || default[n_defaults] == "master"
+  if (invalid) "main" else default[n_defaults]
 }
 
 # This checks if we have set a temporary git user and then unsets it. It will


### PR DESCRIPTION
If a user has multiple `init.defaultBranch` statements in their global git config, then initialising a lesson will fail. This will fix that issue by always taking the _last_ defined branch

This will fix #516

To test this out, it can be installed with either the {pak} or {remotes} packages:

```r
# VIA PAK -----------------------------------
# install.packages("pak")
pak::pkg_install("carpentries/sandpaper#517")

# ===== OR ======

# VIA REMOTES -------------------------------
# install.packages("remotes")
remotes::install_github("carpentries/sandpaper#517")
```

