### PR TITLE
fix 404 page for empty extra info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.13.2
+Version: 0.13.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# sandpaper 0.13.3 (2023-09-22)
+
+- A regression from #514 where empty menus would cause a failure in deployment
+  with the 404 page has been fixed (reported: @tobyhodges and @zkamvar, #519;
+  fixed: @zkamvar, #520).
+
 # sandpaper 0.13.2 (2023-09-20)
 
 ## BUG FIX

--- a/R/utils-sidebar.R
+++ b/R/utils-sidebar.R
@@ -181,7 +181,7 @@ update_sidebar <- function(
     return(sidebar)
   }
   this_sidebar <- sidebar$get()[["sidebar"]]
-  # When there is no title defined, we extract it from the links. 
+  # When there is no title defined, we extract it from the links.
   if (is.null(title)) {
     item <- grep(
       paste0("[<]a href=['\"]", this_page, "['\"]"),
@@ -252,10 +252,22 @@ update_sidebar <- function(
 #'
 #'
 #' # Add an anchor to the links
-#' snd$fix_sidebar_href(my_links, scheme = "https", server = "example.com")
+#' snd$fix_sidebar_href(my_links, scheme = "https", fragment = "anchor")
+#' 
+#' # NOTE: this will _always_ return a character vector, even if the input is
+#' # incorrect
+#' snd$fix_sidebar_href(list(), server = "example.com")
 fix_sidebar_href <- function(
     item, path = NULL, scheme = NULL,
     server = NULL, query = NULL, fragment = NULL) {
+  # exit early if nothing exists
+  has_zero_length <- length(item) == 0L
+  is_not_string <- !is.character(item)
+  is_empty_string <- is.character(item) && length(item) == 1L && item == ""
+  is_not_correct <- has_zero_length || is_not_string || is_empty_string
+  if (is_not_correct) {
+    return("")
+  }
   html <- xml2::read_html(paste(item, collapse = "\n"))
   link <- xml2::xml_find_all(html, ".//a")
   href <- xml2::xml_attr(link, "href")

--- a/man/fix_sidebar_href.Rd
+++ b/man/fix_sidebar_href.Rd
@@ -75,6 +75,10 @@ snd$fix_sidebar_href(my_links, server = "https://example.com")
 
 
 # Add an anchor to the links
-snd$fix_sidebar_href(my_links, scheme = "https", server = "example.com")
+snd$fix_sidebar_href(my_links, scheme = "https", fragment = "anchor")
+
+# NOTE: this will _always_ return a character vector, even if the input is
+# incorrect
+snd$fix_sidebar_href(list(), server = "example.com")
 }
 \keyword{internal}

--- a/tests/testthat/test-utils-sidebar.R
+++ b/tests/testthat/test-utils-sidebar.R
@@ -88,3 +88,15 @@ test_that("updating a sidebar for all pages modifies appropriately", {
 })
 
 
+
+test_that("fix_sidebar_href will return empty string if given empty string", {
+
+  expect_equal(fix_sidebar_href("", server = "exampe.com"), "")
+  expect_equal(fix_sidebar_href(character(0), server = "exampe.com"), "")
+  expect_equal(fix_sidebar_href(NULL, server = "exampe.com"), "")
+  expect_equal(fix_sidebar_href(1:3, server = "exampe.com"), "")
+  expect_equal(fix_sidebar_href(list(), server = "exampe.com"), "")
+
+
+})
+


### PR DESCRIPTION
This is a quick fix to address the problem where a lesson author or maintainer
only specifies `setup.md` in the `learners:` item in `config.yaml`, causing the
`more` menu to be empty, which caused a failure in building the 404 page on 
Continuous Integration.

This will fix #519
