### PR TITLE
Avoid partial matching when extracting metadata element

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,10 @@ Authors@R: c(
            family = "Becker",
            role = c("ctb"),
            email = "ebecker@carpentries.org"),
+    person(given = "Hugo",
+           family = "Gruson",
+           role = c("ctb"),
+           email = "hugo.gruson+R@normalesup.org"),
     person())
 Description: We provide tools to build a Carpentries-themed lesson repository
   into an accessible standalone static website. These include local tools and

--- a/R/build_404.R
+++ b/R/build_404.R
@@ -59,7 +59,7 @@ build_404 <- function(pkg, quiet = FALSE) {
   )
   page_globals$instructor$update(this_dat)
   page_globals$learner$update(this_dat)
-  page_globals$meta$update(this_dat)
+  page_globals$metadata$update(this_dat)
 
   build_html(template = "extra", pkg = pkg, nodes = html,
     global_data = page_globals, path_md = "404.html", quiet = quiet)

--- a/R/build_instructor_notes.R
+++ b/R/build_instructor_notes.R
@@ -32,7 +32,7 @@ build_instructor_notes <- function(pkg, pages = NULL, built = NULL, quiet) {
     this_dat$body <- use_learner(html)
     page_globals$learner$update(this_dat)
 
-    page_globals$meta$update(this_dat)
+    page_globals$metadata$update(this_dat)
 
     build_html(
       template = "extra", pkg = pkg, nodes = html,

--- a/R/build_profiles.R
+++ b/R/build_profiles.R
@@ -20,7 +20,7 @@ build_profiles <- function(pkg, quiet) {
   this_dat$body = use_learner(html)
   page_globals$learner$update(this_dat)
 
-  page_globals$meta$update(this_dat)
+  page_globals$metadata$update(this_dat)
 
   build_html(template = "extra", pkg = pkg, nodes = html,
     global_data = page_globals, path_md = "profiles.html", quiet = quiet)

--- a/tests/testthat/test-set_dropdown.R
+++ b/tests/testthat/test-set_dropdown.R
@@ -20,7 +20,7 @@ cli::test_that_cli("set_config() will set individual items", {
   expect_snapshot(
     set_config(list("title" = "test: title", "license" = "CC0"), path = tmp)
   )
-}, config = c("plain"))
+}, configs = c("plain"))
 
 cli::test_that_cli("set_config() will write items", {
   fs::file_copy(tcfg, this_cfg, overwrite = TRUE)


### PR DESCRIPTION
This removes the partial matching warnings I was seeing.

I'm seeing some test failures locally but it looks like it's because I'm missing some files or because I'm using different system library versions. Let's try it on CI.

Fix #525 