### PR TITLE
Add handout options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Authors@R: c(
     person(given = "Rob",
            family = "Davey",
            role = c("ctb"),
-           email = "robertdavey@carpentries.org")¸
+           email = "robertdavey@carpentries.org"),
     person())
 Description: We provide tools to build a Carpentries-themed lesson repository
   into an accessible standalone static website. These include local tools and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,10 @@ Authors@R: c(
            family = "Gruson",
            role = c("ctb"),
            email = "hugo.gruson+R@normalesup.org"),
+    person(given = "Rob",
+           family = "Davey",
+           role = c("ctb"),
+           email = "robertdavey@carpentries.org")¸
     person())
 Description: We provide tools to build a Carpentries-themed lesson repository
   into an accessible standalone static website. These include local tools and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sandpaper 0.14.0.9000 (unreleased)
+
+## NEW FEATURES
+
+* Using `handout: true` in `config.yaml` will cause a handout to be generated
+  for the lesson website under `/files/code-handout.R`. At the moment, this is
+  only relevant for R-based lessons (implemented: @froggleston, #527) and
+  supersedes the need for specifying `options(sandpaper.handout = TRUE)`
+
 # sandpaper 0.14.0 (2023-10-02)
 
 ## NEW FEATURES

--- a/R/build_handout.R
+++ b/R/build_handout.R
@@ -1,5 +1,5 @@
 #' Create a code handout of challenges without solutions
-#' 
+#'
 #' This function will build a handout and save it to `files/code-handout.R`
 #' in your lesson website. This will build with your website if you enable it
 #' with `options(sandpaper.handout = TRUE)` or if you want to specify a path,

--- a/R/build_handout.R
+++ b/R/build_handout.R
@@ -11,7 +11,7 @@
 #' @param out the path to the handout document. When this is `NULL` (default)
 #'   or `TRUE`, the output will be `site/built/files/code-handout.R`.
 #' @return NULL
-build_handout <- function(path = ".", out = getOption("sandpaper.handout", NULL)) {
+build_handout <- function(path = ".", out = NULL) {
   path <- root_path(path)
   lesson <- this_lesson(path)
   tmp <- fs::file_temp(ext = "R")

--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -102,7 +102,7 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE, slug = NU
     # produces the default headings, challenges, code, etc
     # TODO: this needs improving to allow users to choose what to include based
     # on a yaml list
-    handout <- !is.null(handout) || handout
+    handout <- if (is.null(handout)) FALSE else handout
     should_build_handout <- !isFALSE(handout)
     if (should_build_handout) {
       build_handout(path, out = handout)

--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -96,7 +96,13 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE, slug = NU
         error   = error
       )
     }
-    handout <- getOption("sandpaper.handout", default = FALSE)
+
+    handout <- this_metadata$get()[["handout"]]
+
+    # produces the default headings, challenges, code, etc
+    # TODO: this needs improving to allow users to choose what to include based
+    # on a yaml list
+    handout <- !is.null(handout) || handout
     should_build_handout <- !isFALSE(handout)
     if (should_build_handout) {
       build_handout(path, out = handout)

--- a/R/options.R
+++ b/R/options.R
@@ -7,7 +7,6 @@
 #'@details 
 #' 
 #' ```
-#' option("sandpaper.handout" = TRUE)
 #' option("sandpaper.show_draft" = TRUE)
 #' option("sandpaper.links" = NULL)
 #' option("sandpaper.use_renv" = FALSE)
@@ -18,13 +17,6 @@
 #' As of 2022-02-22, there are several options that are used in sandpaper that
 #' may be manipulated by the user. This set may change in the future, but here
 #' are the description of these options and how they are set on startup:
-#'
-#' ### sandpaper.handout
-#' 
-#' **Default: `FALSE`** This option instructs {sandpaper} to create a handout
-#' of all RMarkdown files via {pegboard}, which uses [knitr::purl()] in the
-#' background after removing everything but the challenges (without solutions)
-#' and any code blocks where `purl = TRUE`.
 #'
 #' ### sandpaper.show_draft
 #'

--- a/R/set_dropdown.R
+++ b/R/set_dropdown.R
@@ -110,6 +110,12 @@ set_dropdown <- function(path = ".", order = NULL, write = FALSE, folder) {
 #' - **overview** `[boolean]` All lessons must have episodes with the exception
 #'   of overview lessons. To indicate that your lesson serves as an overview for
 #'   other lessons, use `overview: true`
+#' - **handout** `[boolean]` or `[character]` This option instructs {sandpaper}
+#'   to create a handout of all RMarkdown files via {pegboard}, which uses
+#'   [knitr::purl()] in the background after removing everything but the
+#'   challenges (without solutions) and any code blocks where `purl = TRUE`. The
+#'   default path for the handout is `files/code-handout.R`
+#'
 #'
 #' As the workbench becomes more developed, some of these optional keys may
 #' disappear.

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -177,7 +177,7 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
   }
   remotes <- tryCatch(gert::git_remote_list(repo = repo),
     error = function(e) {
-      cli::cli_alert_danger(paste0("error from {.code {capture.output(e$call)}}"))
+      cli::cli_alert_danger("Error listing remotes")
       cli::cli_text(e$message)
       d <- data.frame(name = character(0))
       return(d)
@@ -186,11 +186,11 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
   if (any(the_remote <- remotes$name %in% name)) {
     gert::git_remote_remove(name, repo)
     to_remove <- remotes$url[the_remote]
+    cli::cli_alert_info("removing '{name}' ({.file {to_remove}})"
     # don't error if we can not delete this.
     res <- tryCatch(fs::dir_delete(to_remove),
       error = function(e) {
-        e$message <- paste0("error from within: ", e$message)
-        cli::cli_alert_danger(paste0("error from {.code {capture.output(e$call)}}"))
+        cli::cli_alert_danger("Error trying to remove remote")
         cli::cli_text(e$message)
         return(FALSE)
       }

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -177,7 +177,8 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
   }
   remotes <- tryCatch(gert::git_remote_list(repo = repo),
     error = function(e) {
-      e$message <- paste0("error from within: ", e$message)
+      cli::cli_alert_danger(paste0("error from {.code {capture.output(e$call)}}"))
+      cli::cli_text(e$message)
       d <- data.frame(name = character(0))
       return(d)
     }
@@ -189,6 +190,8 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
     res <- tryCatch(fs::dir_delete(to_remove),
       error = function(e) {
         e$message <- paste0("error from within: ", e$message)
+        cli::cli_alert_danger(paste0("error from {.code {capture.output(e$call)}}"))
+        cli::cli_text(e$message)
         return(FALSE)
       }
     )

--- a/R/test-fixtures.R
+++ b/R/test-fixtures.R
@@ -186,7 +186,7 @@ remove_local_remote <- function(repo, name = "sandpaper-local") {
   if (any(the_remote <- remotes$name %in% name)) {
     gert::git_remote_remove(name, repo)
     to_remove <- remotes$url[the_remote]
-    cli::cli_alert_info("removing '{name}' ({.file {to_remove}})"
+    cli::cli_alert_info("removing '{name}' ({.file {to_remove}})")
     # don't error if we can not delete this.
     res <- tryCatch(fs::dir_delete(to_remove),
       error = function(e) {

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -158,6 +158,8 @@ create_pkgdown_yaml <- function(path) {
   # The user does not interact with this and {{mustache}} is logic-less, so we
   # can be super-verbose here and create any logic we need on the R-side.
   usr <- yaml::read_yaml(path_config(path), eval.expr = FALSE)
+  handout <- if (is.null(usr$handout)) "~" else handout
+  handout <- if (isTRUE(handout)) "files/code-handout.R" else handout
   yaml <- get_yaml_text(template_pkgdown())
   yaml <- whisker::whisker.render(yaml,
     data = list(
@@ -174,7 +176,7 @@ create_pkgdown_yaml <- function(path) {
       carpentry      = siQuote(usr$carpentry),
       carpentry_icon = siQuote(which_icon_carpentry(usr$carpentry)),
       license        = siQuote(usr$license),
-      handout        = if (getOption("sandpaper.handout", default = FALSE)) "'files/code-handout.R'" else "~",
+      handout        = siQuote(handout),
       cp             = usr$carpentry == 'cp',
       lc             = usr$carpentry == 'lc',
       dc             = usr$carpentry == 'dc',

--- a/R/utils-yaml.R
+++ b/R/utils-yaml.R
@@ -158,7 +158,7 @@ create_pkgdown_yaml <- function(path) {
   # The user does not interact with this and {{mustache}} is logic-less, so we
   # can be super-verbose here and create any logic we need on the R-side.
   usr <- yaml::read_yaml(path_config(path), eval.expr = FALSE)
-  handout <- if (is.null(usr$handout)) "~" else handout
+  handout <- if (is.null(usr$handout)) "~" else usr$handout
   handout <- if (isTRUE(handout)) "files/code-handout.R" else handout
   yaml <- get_yaml_text(template_pkgdown())
   yaml <- whisker::whisker.render(yaml,

--- a/man/build_handout.Rd
+++ b/man/build_handout.Rd
@@ -4,7 +4,7 @@
 \alias{build_handout}
 \title{Create a code handout of challenges without solutions}
 \usage{
-build_handout(path = ".", out = getOption("sandpaper.handout", NULL))
+build_handout(path = ".", out = NULL)
 }
 \arguments{
 \item{path}{the path to the lesson. Defaults to current working directory}

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -32,6 +32,7 @@ Other contributors:
   \item Kelly Barnes \email{kbarnes@carpentries.org} [contributor]
   \item Erin Becker \email{ebecker@carpentries.org} [contributor]
   \item Hugo Gruson \email{hugo.gruson+R@normalesup.org} [contributor]
+  \item Rob Davey \email{robertdavey@carpentries.org} [contributor]
 }
 
 }

--- a/man/sandpaper.options.Rd
+++ b/man/sandpaper.options.Rd
@@ -7,8 +7,7 @@
 this is some documentation about options
 }
 \details{
-\if{html}{\out{<div class="sourceCode">}}\preformatted{option("sandpaper.handout" = TRUE)
-option("sandpaper.show_draft" = TRUE)
+\if{html}{\out{<div class="sourceCode">}}\preformatted{option("sandpaper.show_draft" = TRUE)
 option("sandpaper.links" = NULL)
 option("sandpaper.use_renv" = FALSE)
 option("sandpaper.package_cache_trigger" = FALSE)
@@ -18,14 +17,6 @@ option("sandpaper.test_fixture" = NULL)
 As of 2022-02-22, there are several options that are used in sandpaper that
 may be manipulated by the user. This set may change in the future, but here
 are the description of these options and how they are set on startup:
-\subsection{sandpaper.handout}{
-
-\strong{Default: \code{FALSE}} This option instructs {sandpaper} to create a handout
-of all RMarkdown files via {pegboard}, which uses \code{\link[knitr:knit]{knitr::purl()}} in the
-background after removing everything but the challenges (without solutions)
-and any code blocks where \code{purl = TRUE}.
-}
-
 \subsection{sandpaper.show_draft}{
 
 \strong{Default: \code{TRUE}} This is for user messages. If \code{TRUE}, a message about

--- a/man/set_config.Rd
+++ b/man/set_config.Rd
@@ -58,6 +58,11 @@ site that indicates the site is in the workbench beta phase.
 \item \strong{overview} \verb{[boolean]} All lessons must have episodes with the exception
 of overview lessons. To indicate that your lesson serves as an overview for
 other lessons, use \code{overview: true}
+\item \strong{handout} \verb{[boolean]} or \verb{[character]} This option instructs {sandpaper}
+to create a handout of all RMarkdown files via {pegboard}, which uses
+\code{\link[knitr:knit]{knitr::purl()}} in the background after removing everything but the
+challenges (without solutions) and any code blocks where \code{purl = TRUE}. The
+default path for the handout is \code{files/code-handout.R}
 }
 
 As the workbench becomes more developed, some of these optional keys may

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -33,7 +33,10 @@ withr::defer({
   if (noise) {
     status <- if (identical(res, FALSE)) "could not be" else "successfully"
     cli::cli_alert_info("{.file {tf}} {status} removed")
-    status <- if (is.character(rem)) "successfully" else "could not be"
-    cli::cli_alert_info("local remote {.file {rem}} {status} removed")
+    if (is.character(rem)) {
+      cli::cli_alert_info("local remote {.file {rem}} successfully removed")
+    } else {
+      cli::cli_alert_info("local remote could not be removed")
+    }
   }
 }, teardown_env())

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -170,7 +170,7 @@ test_that("Artifacts are accounted for", {
   # Testing for generated figures included ------------------------
   figs <- paste0(fs::path_ext_remove(s), "-rendered-pyramid-1.png")
   a <- fs::dir_ls(fs::path(tmp, "site", "built"), recurse = TRUE, type = "file")
-  expect_setequal(fs::path_file(a), c(figs, b))
+  expect_setequal(fs::path_file(a), c(figs, b, "code-handout.R"))
 
 })
 

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -33,7 +33,16 @@ test_that("markdown sources can be built without fail", {
   rmarkdown::render(instruct, quiet = TRUE)
   expect_true(fs::file_exists(fs::path_ext_set(instruct, "html")))
 
-  withr::local_options(list(sandpaper.handout = TRUE))
+  # keep original config in a tmp file
+  tmp_config <- withr::local_tempfile()
+  fs::file_copy(fs::path(res, "config.yaml"), tmp_config)
+  # clean up by replacing config with original
+  withr::defer({
+    fs::file_copy(tmp_config, fs::path(res, "config.yaml"))
+  }, priority = "first"
+  )
+  writeLines("handout: true\n", fs::path(res, "config.yaml"))
+
   # It's noisy at first
   suppressMessages({
     build_markdown(res, quiet = FALSE) %>%

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -38,10 +38,10 @@ test_that("markdown sources can be built without fail", {
   fs::file_copy(fs::path(res, "config.yaml"), tmp_config)
   # clean up by replacing config with original
   withr::defer({
-    fs::file_copy(tmp_config, fs::path(res, "config.yaml"))
+    fs::file_copy(tmp_config, fs::path(res, "config.yaml"), overwrite = TRUE)
   }, priority = "first"
   )
-  writeLines("handout: true\n", fs::path(res, "config.yaml"))
+  cat("handout: true\n", file = fs::path(res, "config.yaml"), append = TRUE)
 
   # It's noisy at first
   suppressMessages({

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -1,24 +1,24 @@
 # setup test fixture
 {
-tmp <- res <- restore_fixture()
-create_episode("second-episode", path = tmp)
-instruct <- fs::path(tmp, "instructors", "pyramid.md")
-writeLines(c(
-  "---",
-  "title: Pyramid",
-  "---\n",
-  "One of the best albums by MJQ"
- ),
-  con = instruct
-)
-fs::file_copy(instruct, fs::path(tmp, "learners", "dimaryp.md"))
-set_globals(res)
-withr::defer(clear_globals())
+  tmp <- res <- restore_fixture()
+  create_episode("second-episode", path = tmp)
+  instruct <- fs::path(tmp, "instructors", "pyramid.md")
+  writeLines(
+    c(
+      "---",
+      "title: Pyramid",
+      "---\n",
+      "One of the best albums by MJQ"
+    ),
+    con = instruct
+  )
+  fs::file_copy(instruct, fs::path(tmp, "learners", "dimaryp.md"))
+  set_globals(res)
+  withr::defer(clear_globals())
 }
 
 
 test_that("markdown sources can be built without fail", {
-
   suppressMessages(s <- get_episodes(tmp))
   set_episodes(tmp, s, write = TRUE)
   set_learners(tmp, "dimaryp.md", write = TRUE)
@@ -84,15 +84,12 @@ test_that("changes in config.yaml triggers a rebuild of the site yaml", {
   })
 
   expect_identical(get_path_site_yaml(res)$title, "NEW: Lesson Title")
-
-
 })
 
 
 
 
 test_that("markdown sources can be rebuilt without renv", {
-
   # no building needed
   skip_on_os("windows")
   suppressMessages({
@@ -115,7 +112,6 @@ test_that("markdown sources can be rebuilt without renv", {
 })
 
 test_that("modifying a file suffix will force the file to be rebuilt", {
-
   instruct <- fs::path(tmp, "instructors", "pyramid.md")
   instruct_rmd <- fs::path_ext_set(instruct, "Rmd")
   expect_true(fs::file_exists(instruct))
@@ -144,7 +140,6 @@ test_that("modifying a file suffix will force the file to be rebuilt", {
 })
 
 test_that("Artifacts are accounted for", {
-
   s <- get_episodes(tmp)
   # The artifacts are present in the built directory
   b <- c(
@@ -169,15 +164,14 @@ test_that("Artifacts are accounted for", {
   expect_equal(fs::path_file(e), s, ignore_attr = TRUE)
 
   # Testing for top-level artifacts -------------------------------
-  folders <- c( "data", "fig", "files")
+  folders <- c("data", "fig", "files")
   a <- fs::dir_ls(fs::path(tmp, "site", "built"))
   expect_setequal(fs::path_file(a), c(folders, b))
 
   # Testing for generated figures included ------------------------
   figs <- paste0(fs::path_ext_remove(s), "-rendered-pyramid-1.png")
   a <- fs::dir_ls(fs::path(tmp, "site", "built"), recurse = TRUE, type = "file")
-  expect_setequal(fs::path_file(a), c(figs, b, "code-handout.R"))
-
+  expect_setequal(fs::path_file(a), c(figs, b))
 })
 
 test_that("Hashes are correct", {
@@ -186,28 +180,25 @@ test_that("Hashes are correct", {
   h2 <- expect_hashed(res, "second-episode.Rmd")
   # the hashes will no longer be equal because the titles are now different
   expect_failure(expect_equal(h1, h2, ignore_attr = TRUE))
-
 })
 
 test_that("Output is not commented", {
   # Output is not commented
-  built  <- get_markdown_files(res)
+  built <- get_markdown_files(res)
   built_file <- grep("introduction.md$", built)
-  ep     <- trimws(readLines(built[[built_file]]))
-  ep     <- ep[ep != ""]
-  outid  <- grep("[1]", ep, fixed = TRUE)
+  ep <- trimws(readLines(built[[built_file]]))
+  ep <- ep[ep != ""]
+  outid <- grep("[1]", ep, fixed = TRUE)
   output <- ep[outid[1]]
-  fence  <- ep[outid[1] - 1]
+  fence <- ep[outid[1] - 1]
 
   # code output lines start with normal R indexing ---------------
   expect_match(output, "^\\[1\\]")
   # code output fences have the output class ---------------------
   expect_match(fence, "^[`]{3}[{]?\\.?output[}]?")
-
 })
 
 test_that("Markdown rendering does not happen if content is not changed", {
-
   skip_on_os("windows")
 
   suppressMessages({
@@ -231,7 +222,6 @@ test_that("Removing source removes built", {
   reset_episodes(res)
   set_episodes(res, "introduction.Rmd", write = TRUE)
   build_markdown(res, quiet = TRUE)
-#  h1 <- expect_hashed(res, "introduction.Rmd")
   expect_length(get_figs(res, "introduction"), 1)
 
   # The second episode should not exist
@@ -268,7 +258,6 @@ test_that("old md5sum.txt db will work", {
 
   # The new database format is restored
   expect_identical(olddb$file, as.character(newdb$new$file))
-
 })
 
 test_that("dates are preserved in md5sum.txt", {
@@ -283,7 +272,6 @@ test_that("dates are preserved in md5sum.txt", {
   newdb <- build_status(sources, db_path, rebuild = FALSE, write = FALSE)
 
   expect_equal(newdb$new$date, db$date)
-
 })
 
 test_that("Removing partially matching slugs will not have side-effects", {
@@ -300,7 +288,6 @@ test_that("Removing partially matching slugs will not have side-effects", {
   # The image should still exist
   pyramid_fig <- fs::path(built_path, "fig", "introduction-rendered-pyramid-1.png")
   expect_true(fs::file_exists(pyramid_fig))
-
 })
 
 test_that("setting `fail_on_error: true` in config will cause build to fail", {
@@ -345,3 +332,4 @@ test_that("setting `fail_on_error: true` in config will cause build to fail", {
   # fail on error is true
   expect_true(this_metadata$get()[["fail_on_error"]])
 })
+


### PR DESCRIPTION
This PR adds a new option in the `config.yaml` to support configuration of whether a handout should be included.

This removes the need to supply `sandpaper.handout = TRUE` in the options() function, but keeps the functionality to either specify `handout: true` or `handout: "/path/to/handout_file.R"`