### PR TITLE
Update utils-varnish.R

### DIFF
--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -35,7 +35,7 @@ varnish_vars <- function() {
 #'
 #' This will enforce four global lists:
 #'
-#'  1. `.resources`, which is equivalent to the output of `get_source_list()`
+#'  1. `.resources`, which is equivalent to the output of `get_resource_list()`
 #'  2. `this_metadata`, which contains the metadata common for the lesson
 #'  2. `learner_globals` the navigation items for the learners
 #'  3. `instructor_globals` the namvigation items for the instructors

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -30,6 +30,8 @@ Other contributors:
   \item Toby Hodges \email{tobyhodges@carpentries.org} [contributor]
   \item François Michonneau \email{francois@carpentries.org} [contributor]
   \item Kelly Barnes \email{kbarnes@carpentries.org} [contributor]
+  \item Erin Becker \email{ebecker@carpentries.org} [contributor]
+  \item Hugo Gruson \email{hugo.gruson+R@normalesup.org} [contributor]
 }
 
 }

--- a/man/set_globals.Rd
+++ b/man/set_globals.Rd
@@ -14,7 +14,7 @@ This will enforce four global lists:
 }
 \details{
 \enumerate{
-\item \code{.resources}, which is equivalent to the output of \code{get_source_list()}
+\item \code{.resources}, which is equivalent to the output of \code{get_resource_list()}
 \item \code{this_metadata}, which contains the metadata common for the lesson
 \item \code{learner_globals} the navigation items for the learners
 \item \code{instructor_globals} the namvigation items for the instructors


### PR DESCRIPTION
This PR fixes a small typo in the utils-varnish.R file, where in the `set_globals()` function doc, reference is made to `.resources` being equivalent to `get_source_list()`. This function doesn't exist, but rather the doc should reference `get_resource_list()`