### PR TITLE
bump version to release 0.14.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.13.3.9000
+Version: 0.14.0
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -43,7 +43,7 @@ Description: We provide tools to build a Carpentries-themed lesson repository
 License: MIT + file LICENSE
 Imports:
     pkgdown (>= 1.6.0),
-    pegboard (>= 0.6.1.9000),
+    pegboard (>= 0.7.0),
     cli (>= 3.4.0),
     commonmark,
     fs (>= 1.5.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * all internal folders can contain the standard `files`, `fig`, and `data`
   folders with the cautionary note that duplicate file names to other folders
-  will cause an error. 
+  will cause an error.
 - `validate_lesson()` now reports invalid elements of child documents
 - A new vignette `vignette("include-child-documents", package = "sandpaper")`
   demonstrates and describes the caveats about using child documents.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# sandpaper 0.13.3.9000 (unreleased)
+# sandpaper 0.14.0 (2023-10-02)
 
 ## NEW FEATURES
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,7 +54,7 @@ install.packages("sandpaper", dep = TRUE)
 
 Note that this will also install development versions of the following packages:
 
-| package      | What it does | 
+| package      | What it does |
 | -------------| ------------ |
 | [{varnish}]  | html, css, and javascript templates for The Carpentries (in progress) |
 | [{tinkr}]    | manipulation of knitr markdown documents built on the commonmark xml library |


### PR DESCRIPTION
Note: this must be preceded by https://github.com/carpentries/pegboard/pull/138