### PR TITLE
expand instructor extras

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.14.0
+Version: 0.14.0.9000
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.14.0.9000 (unreleased)
+
+* Content for learners now accessible through instructor view. The instructor
+  view "More" dropdown menu item will now have links to learner view items
+  appended. Note that when clicking these links, the user will remain in
+  instructor view. This behaviour may change in future iterations (reported:
+  @karenword, #394; fixed: @ErinBecker, #530, reviewed: @zkamvar)
+
 # sandpaper 0.14.0 (2023-10-02)
 
 ## NEW FEATURES

--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -44,7 +44,7 @@ varnish_vars <- function() {
 #'
 #'  - `sidebar` This is generated from [create_sidebar()] and is the same in the
 #'    learner and instructor globals with the exception of the first element.
-#'  - `more` This is the "More" dorpdown menu, which is created via [create_resources_dropdown()].
+#'  - `more` This is the "More" dropdown menu, which is created via [create_resources_dropdown()].
 #'  - `resources` The same as "More", but positioned on the mobile sidebar.
 #'  - `{sandpaper,varnish,pegboard}_version` package versions of each package.
 #'
@@ -83,8 +83,8 @@ set_globals <- function(path) {
   # Resources
   learner <- create_resources_dropdown(these_resources[["learners"]],
     "learners")
-  instructor <- create_resources_dropdown(these_resources[["instructors"]],
-    "instructors")
+  instructor_all <- c(these_resources$instructors, these_resources$learners)
+  instructor <- create_resources_dropdown(instructor_all, "instructors")
   pkg_versions <- varnish_vars()
 
   learner_globals$set(key = NULL,
@@ -124,4 +124,3 @@ clear_globals <- function() {
   instructor_globals$clear()
   this_metadata$clear()
 }
-

--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -83,8 +83,9 @@ set_globals <- function(path) {
   # Resources
   learner <- create_resources_dropdown(these_resources[["learners"]],
     "learners")
-  instructor_all <- c(these_resources$instructors, these_resources$learners)
-  instructor <- create_resources_dropdown(instructor_all, "instructors")
+  instructor <- create_resources_dropdown(these_resources[["instructors"]], "instructors")
+  instructor$extras <- c(instructor$extras, "<hr>", learner$extras)
+  instructor$resources <- c(instructor$resources, "<hr>", learner$extras)
   pkg_versions <- varnish_vars()
 
   learner_globals$set(key = NULL,

--- a/man/set_globals.Rd
+++ b/man/set_globals.Rd
@@ -24,7 +24,7 @@ The things that are added:
 \itemize{
 \item \code{sidebar} This is generated from \code{\link[=create_sidebar]{create_sidebar()}} and is the same in the
 learner and instructor globals with the exception of the first element.
-\item \code{more} This is the "More" dorpdown menu, which is created via \code{\link[=create_resources_dropdown]{create_resources_dropdown()}}.
+\item \code{more} This is the "More" dropdown menu, which is created via \code{\link[=create_resources_dropdown]{create_resources_dropdown()}}.
 \item \code{resources} The same as "More", but positioned on the mobile sidebar.
 \item \verb{\{sandpaper,varnish,pegboard\}_version} package versions of each package.
 }

--- a/tests/testthat/_snaps/build_html.md
+++ b/tests/testthat/_snaps/build_html.md
@@ -30,6 +30,7 @@
       <li>
                               <a href="../instructor/images.html">Extract All Images</a>
                             </li>
+      <li><a class="dropdown-item" href="reference.html">Reference</a></li>
 
 # [build_profiles()] learner and instructor views are identical
 
@@ -42,6 +43,7 @@
       <a href="../instructor/key-points.html">Key Points</a>
       <a href="../instructor/instructor-notes.html">Instructor Notes</a>
       <a href="../instructor/images.html">Extract All Images</a>
+      <a class="dropdown-item" href="reference.html">Reference</a>
       <a href="../instructor/aio.html">See all in one page</a>
 
 ---

--- a/tests/testthat/_snaps/build_lesson.md
+++ b/tests/testthat/_snaps/build_lesson.md
@@ -10,6 +10,7 @@
       <a href="../instructor/key-points.html">Key Points</a>
       <a href="../instructor/instructor-notes.html">Instructor Notes</a>
       <a href="../instructor/images.html">Extract All Images</a>
+      <a class="dropdown-item" href="reference.html">Reference</a>
       <a href="../instructor/aio.html">See all in one page</a>
 
 ---


### PR DESCRIPTION
This PR fixes https://github.com/carpentries/sandpaper/issues/394 by adding all menu items displayed under the More tab in the Learner view to also be displayed in the Instructor view. It's probably not the most elegant way of doing this. Suggestions for improvements welcome!