### PR TITLE
exclude lockfile packages from hydration

### DIFF
--- a/R/utils-renv.R
+++ b/R/utils-renv.R
@@ -250,6 +250,12 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
     deps <- unique(renv::dependencies(path = path, root = path, dev = TRUE)$Package)
     pkgs <- setdiff(deps, installed)
     needs_hydration <- length(pkgs) > 0
+    if (packageVersion("renv") >= "1.0.0") {
+      # We only need to hydrate the packages that do not exist in the lockfile
+      # and that are not installed
+      lock <- renv::lockfile_read(renv_lock)
+      pkgs <- setdiff(pkgs, names(lock$Packages))
+    }
   } else {
     # If there is not a lockfile, we need to run a fully hydration
     pkgs <- NULL


### PR DESCRIPTION
This addresses a bug where a GitHub package would fail to be provisioned even if it is recorded in the lockfile.
(see https://github.com/carpentries/sandpaper/issues/221#issuecomment-1777952955)


NOTE: I am trying a patch release here directly from the 0.14.0 tag.
