### PR TITLE
hotfix: do not transform mailto links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.14.0
+Version: 0.14.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.14.1 (2023-11-09)
+
+## BUG FIX
+
+* `mailto:` links are no longer prepended with the URL (reported: @apirogov,
+  #538; fixed: @zkamvar, #539)
+
 # sandpaper 0.14.0 (2023-10-02)
 
 ## NEW FEATURES

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -144,9 +144,12 @@ use_instructor <- function(nodes = NULL) {
   if (length(nodes) == 0) return(nodes)
   copy <- xml2::read_html(as.character(nodes))
   # find all local links and transform non-html and nested links ---------
-  lnk <- xml2::xml_find_all(copy,
-    ".//a[@href][not(contains(@href, '://')) and not(starts-with(@href, '#'))]"
-  )
+  no_external <- "not(contains(@href, '://'))"
+  no_anchors  <- "not(starts-with(@href, '#'))"
+  no_mail     <- "not(starts-with(@href, 'mailto:'))"
+  predicate <- paste(c(no_external, no_anchors, no_mail), collapse = " and ")
+  XPath <- sprintf(".//a[@href][%s]", predicate)
+  lnk <- xml2::xml_find_all(copy, XPath)
   lnk_hrefs <- xml2::xml_attr(lnk, "href")
   lnk_paths <- xml2::url_parse(lnk_hrefs)$path
   # links without HTML extension

--- a/tests/testthat/_snaps/utils-xml.md
+++ b/tests/testthat/_snaps/utils-xml.md
@@ -3,7 +3,7 @@
     Code
       xml2::xml_find_all(html_test, ".//a[@href]")
     Output
-      {xml_nodeset (10)}
+      {xml_nodeset (11)}
        [1] <a href="index.html">a</a>
        [2] <a href="./index.html">b</a>
        [3] <a href="fig/thing.png">c</a>
@@ -14,13 +14,14 @@
        [8] <a href="#what-the">h</a>
        [9] <a href="other-page.html#section">i</a>
       [10] <a href="other-page">j</a>
+      [11] <a href="mailto:workbench@example.com?subject='no'">k</a>
 
 ---
 
     Code
       xml2::xml_find_all(res, ".//a[@href]")
     Output
-      {xml_nodeset (10)}
+      {xml_nodeset (11)}
        [1] <a href="index.html">a</a>
        [2] <a href="./index.html">b</a>
        [3] <a href="../fig/thing.png">c</a>
@@ -31,4 +32,5 @@
        [8] <a href="#what-the">h</a>
        [9] <a href="other-page.html#section">i</a>
       [10] <a href="other-page">j</a>
+      [11] <a href="mailto:workbench@example.com?subject='no'">k</a>
 

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -12,13 +12,14 @@ test_that("paths in instructor view that are nested or not HTML get diverted", {
     "[g](files/confirmation.html)", # asset
     "[h](#what-the)",
     "[i](other-page.html#section)",
-    "[j](other-page)"
+    "[j](other-page)",
+    "[k](mailto:workbench@example.com?subject='no')"
   )))
   res <- xml2::read_html(use_instructor(html_test))
   # refs are transformed according to our rules
   refs <- xml2::xml_text(xml2::xml_find_all(res, ".//@href"))
   expect_equal(startsWith(refs, "../"),
-    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE))
+    c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE))
   expect_snapshot(xml2::xml_find_all(html_test, ".//a[@href]"))
   expect_snapshot(xml2::xml_find_all(res, ".//a[@href]"))
 })


### PR DESCRIPTION
This will fix #538

Note: I am going to do a patch release of this where I bump the version and NEWS here, add a tag, and then make a release from that tag.