### PR TITLE
Remove text that does not apply to this repo 

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -3,7 +3,7 @@ name: Bug report or feature request
 about: Describe a bug you've seen or make a case for a new feature
 ---
 
-Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+Please briefly describe your problem and what output you expect.
 
 Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
 


### PR DESCRIPTION
the issue template maybe should get more updates, but this seems like an easy win. 

Remaining issues: (can be sent into issues  or added here)
- it says is a template for bug or feature, but it only has helper text for bugs. 
- (unsure) the reprex being defaulted to R code may not be necessary? 