### PR TITLE
enforce lf line ending for shim

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/pkgdown/shim.R text eol=lf


### PR DESCRIPTION
This should avoid the situation we found on @klbarnes20's machine and confirmed on @froggleston's machine where Git is forcing CRLF line endings. Instead of having both set `core.autocrlf=input`, this `.gitattributes` file should enforce this file having lf line endings.

@klbarnes20, can you test this on your computer by cloning this branch:

```sh
git clone --branch lf-line-endings-shim https://github.com/carpentries/sandpaper
```

and then running this in R (inside the just-cloned repo)

```r
stopifnot(tools::md5sum("inst/pkgdown/shim.R") == "230853fec984d1a0e5766d3da79f1cea")
```
