### PR TITLE
prevent duplication of callout heading text with markup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.16.0
+Version: 0.16.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.16.1 (2023-12-14)
+
+## BUG FIX
+
+* Callout headings with markup in the titles will no longer have text duplicated
+  (reported: @zkamvar, #556; fixed: @zkamvar, #557)
+
 # sandpaper 0.16.0 (2023-12-13)
 
 ## NEW FEATURES

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -198,7 +198,9 @@ fix_callouts <- function(nodes = NULL) {
   callouts <- xml2::xml_find_all(nodes, ".//div[starts-with(@class, 'callout ')]")
   h3 <- xml2::xml_find_all(callouts, "./div/h3")
   translations <- get_callout_translations()
-  xml_text_translate(h3, translations)
+  # https://github.com/carpentries/sandpaper/issues/556
+  h3_text <- xml2::xml_find_all(h3, ".//text()")
+  xml_text_translate(h3_text, translations)
   xml2::xml_set_attr(h3, "class", "callout-title")
   inner_div <- xml2::xml_parent(h3)
   # remove the "section level3 callout-title" attrs

--- a/tests/testthat/examples/callout-ids.html
+++ b/tests/testthat/examples/callout-ids.html
@@ -9,7 +9,7 @@
           <i class="callout-icon" data-feather="message-circle"></i>
         </div>
         <div class="section level3 callout-title callout-inner">
-          <h3 class="callout-title">Challenge</h3>
+          <h3 class="callout-title">Challenge (<code>this is code</code>)</h3>
           <div class="callout-content">
             <p>How do you write markdown divs?</p>
           </div>

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -51,7 +51,7 @@ test_that("fix figures account for inline images and do not clobber them into fi
 
 
 
-test_that("callout are processed correctly", {
+test_that("(#556) (#454) callout are processed correctly", {
   html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
   fix_callouts(html_test)
   anchors <- xml2::xml_find_all(html_test, ".//a")
@@ -71,6 +71,7 @@ test_that("callout are processed correctly", {
   # The IDs should match the anchors
   expect_equal(paste0("#", ids), xml2::xml_attr(anchors, "href"))
   # The headings should match what we expect
+  # (https://github.com/carpentries/sandpaper/issues/556)
   htext <- xml2::xml_find_all(headings, ".//text()")
   expect_equal(xml2::xml_text(htext), 
     c("Challenge (", "this is code", ")", "Wait what?"))

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -51,7 +51,7 @@ test_that("fix figures account for inline images and do not clobber them into fi
 
 
 
-test_that("callout ids are processed correctly", {
+test_that("callout are processed correctly", {
   html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
   fix_callouts(html_test)
   anchors <- xml2::xml_find_all(html_test, ".//a")
@@ -70,6 +70,10 @@ test_that("callout ids are processed correctly", {
   expect_equal(ids, c("discussion1", "wait-what"))
   # The IDs should match the anchors
   expect_equal(paste0("#", ids), xml2::xml_attr(anchors, "href"))
+  # The headings should match what we expect
+  htext <- xml2::xml_find_all(headings, ".//text()")
+  expect_equal(xml2::xml_text(htext), 
+    c("Challenge (", "this is code", ")", "Wait what?"))
 })
 
 


### PR DESCRIPTION
This will fix #556 by preventing the callout heading content from being duplicated. This issue was occurring because I had an incomplete mental model of how text nodes should be manipulated.

According to the [xml2's Node Manipulation vignette](https://xml2.r-lib.org/articles/modification.html#text-modification) text manipulation should be done by explicitly selecting `/text()`.

This bumps the version to 0.16.1 to be released immediately 