### PR TITLE
Add support for tabs / tabset panels

### DIFF
--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -356,9 +356,9 @@ end
 
 tab_filter = {
   Header = function(el)
-    -- Level 1 headers mark the tab titles
+    -- Level 3 headers mark the tab titles
     -- all other headers in a tab block are ignored
-    if el.level == 1 then
+    if el.level == 3 then
 
       -- Insert the title for the add_to_tabpanel to access
       local title = pandoc.utils.stringify(el)
@@ -418,6 +418,12 @@ tab_filter = {
     _ = add_to_tabpanel(el)
   end,
   CodeBlock = function(el)
+    _ = add_to_tabpanel(el)
+  end,
+  OrderedList = function(el)
+    _ = add_to_tabpanel(el)
+  end,
+  BulletList = function(el)
     _ = add_to_tabpanel(el)
   end
 }

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -369,11 +369,16 @@ tab_filter = {
         local tab_id = block_counts["group-tab"]
         local title_no_spaces = title:gsub("%s+", "")
         id = tab_id.."-"..title_no_spaces
+        -- The JS for the group tabs selects buttons
+        -- to show based on the name attribute.
+        -- Here we set it to the button title.
         name = 'name="'..title_no_spaces..'"'
+        -- Store the title so it can be used in the tabpanel id
         table.insert(group_tab_titles, title_no_spaces)
       else
         local tab_id = block_counts["tab"]
         id = tab_id.."-"..tab_button_num+1
+        -- Non group tabs don't need a name attribute.
         name = ""
       end
 


### PR DESCRIPTION
**What:** This pull request adds support for **tab** and **group-tab** admonitions/panels. They are based off [sphinx-tabs](https://sphinx-tabs.readthedocs.io/en/latest/). It does this by adding an extra lua filter.

**Why:** So I can have a tab of instructions for each computer platform which sync (group-tabs) across episodes. Tabs are also useful when teaching compiled languages as I can have a tab for each compiler.

## Syntax:

### tab

````
::: tab

# gnu

1

# Intel

2

# Craaaay

This is some text before the code block.

```fortran
  print *, 'WHAT is Cray today'
```

Text after

:::
````

Output:

![tab](https://github.com/carpentries/sandpaper/assets/64108146/eb7de5b7-49b3-4bb8-8b46-24353d30c7df)

### group-tab

```
::: group-tab

# Linux

1

# Windows

2

# Archer

3

:::

::: group-tab

# Linux

4

# Windows

5

# Archer

6

:::
```

Output:

![group-tab](https://github.com/carpentries/sandpaper/assets/64108146/d247db04-fad8-4d8a-9f10-0cf6edc9fa43)


The underlying functionality is all handled by [bootstrap tabs](https://getbootstrap.com/docs/5.0/components/navs-tabs/). I have used the resources mentioned in https://github.com/carpentries/varnish/issues/32 to get the aria labels right and the JS is based of sphinx-tabs.

## Caveats

- Only text, images, and code blocks can be inside a tab. I tried getting the filter to accept other callouts inside a tab. Since any nested callout is processed first and the other callouts (say spoiler) are made up of any number of divs and other elements inside I couldn't find a way to soley capture the main 'spoiler' div for instance to go inside a block. Contrast this with a code block which is processed as one single div element by the filter and can easily be inserted in the tabpanel. I tried writing the filter so that it walked inlines not blocks and just couldn't get other callouts to work inside tabs. For my use case I don't see this as a huge issue but maybe others have different use cases.
- Use of global lua variables - I had to add a few more. The filter would normally process and return elements in order so header 1, then content 1 for the first tab etc. I wanted to collate all the headers for the nav tablist and collate all the tabcontent to go below the nav as in the [bootstrap example](https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior) (the second one in this section using <nav>. That meant storing the buttons and content in lua tables so they are separate and wrapping them in divs after the main filter has run.
- I have probably missed adding tests, and I tested the built lesson on Firefox and Chrome.

I have added a lot to the lua so I'm happy to have a zoom etc chat if anyone is looking at the code as part of a review.

To test this change you will need the corresponding varnish and pegboard changes:
- https://github.com/carpentries/pegboard/pull/148
- https://github.com/carpentries/varnish/pull/121