### PR TITLE
Add metadata for citation cff (or not)

### DIFF
--- a/R/build_html.R
+++ b/R/build_html.R
@@ -63,6 +63,7 @@ build_html <- function(template = "chapter", pkg, nodes, global_data, path_md, q
   translated <- fill_translation_vars(global_data$instructor$get())
   global_data$instructor$set("json", fill_metadata_template(meta))
   global_data$instructor$set("translate", translated)
+  global_data$instructor$set("citation", meta$get()$citation)
   modified <- pkgdown::render_page(pkg,
     template,
     data = global_data$instructor$get(),
@@ -78,6 +79,7 @@ build_html <- function(template = "chapter", pkg, nodes, global_data, path_md, q
     update_sidebar(global_data$learner, learner_nodes, fs::path_file(this_page))
     meta$set("url", paste0(base_url, this_page))
     global_data$learner$set("json", fill_metadata_template(meta))
+    global_data$learner$set("citation", meta$get()$citation)
     pkgdown::render_page(pkg,
       template,
       data = global_data$learner$get(),

--- a/R/utils-metadata.R
+++ b/R/utils-metadata.R
@@ -33,6 +33,7 @@ initialise_metadata <- function(path = ".") {
   old <- this_metadata$get()
   if (length(old) == 0L) {
     this_metadata$set(NULL, cfg)
+    this_metadata$set("citation", path_citation(path))
     this_metadata$set("metadata_template", readLines(template_metadata()))
     this_metadata$set("pagetitle", cfg$title)
     this_metadata$set("keywords", cfg$keywords)

--- a/R/utils-metadata.R
+++ b/R/utils-metadata.R
@@ -33,7 +33,6 @@ initialise_metadata <- function(path = ".") {
   old <- this_metadata$get()
   if (length(old) == 0L) {
     this_metadata$set(NULL, cfg)
-    this_metadata$set("citation", path_citation(path))
     this_metadata$set("metadata_template", readLines(template_metadata()))
     this_metadata$set("pagetitle", cfg$title)
     this_metadata$set("keywords", cfg$keywords)
@@ -48,6 +47,7 @@ initialise_metadata <- function(path = ".") {
   this_metadata$set("url", metadata_url(cfg))
   this_metadata$set(c("date", "modified"), format(Sys.Date(), "%F"))
   this_metadata$set(c("date", "published"), format(Sys.Date(), "%F"))
+  this_metadata$set("citation", path_citation(path))
 }
 
 

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -28,7 +28,7 @@ path_profiles <- function(inpath) {
 path_citation <- function(inpath) {
   home <- root_path(inpath)
   cff <- "CITATION.cff"
-  cffp <- fs::path(home, cffp)
+  cffp <- fs::path(home, cff)
   if (is.null(cffp)) {
     return("CITATION")
   }

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -25,6 +25,16 @@ path_profiles <- function(inpath) {
   fs::path(home, "profiles")
 }
 
+path_citation <- function(inpath) {
+  home <- root_path(inpath)
+  cff <- "CITATION.cff"
+  cffp <- fs::path(home, cffp)
+  if (is.null(cffp)) {
+    return("CITATION")
+  }
+  return(cff)
+}
+
 
 provide_setup <- function(cfg, setup = "setup.md") {
   if (is.null(cfg) || is.null(cfg$learners)) {

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -29,7 +29,7 @@ path_citation <- function(inpath) {
   home <- root_path(inpath)
   cff <- "CITATION.cff"
   cffp <- fs::path(home, cff)
-  if (file_exists(cffp)) {
+  if (fs::file_exists(cffp)) {
     return(cff)
   }
   return("CITATION")

--- a/R/utils-paths-source.R
+++ b/R/utils-paths-source.R
@@ -29,10 +29,10 @@ path_citation <- function(inpath) {
   home <- root_path(inpath)
   cff <- "CITATION.cff"
   cffp <- fs::path(home, cff)
-  if (is.null(cffp)) {
-    return("CITATION")
+  if (file_exists(cffp)) {
+    return(cff)
   }
-  return(cff)
+  return("CITATION")
 }
 
 


### PR DESCRIPTION
This PR adds support for detection of a CFF citation file in the base folder of a lesson, and adding it to the lesson metadata so it can be used by varnish in lesson footers.