### PR TITLE
Upgrade official actions from GitHub

### DIFF
--- a/inst/workflows/pr-close-signal.yaml
+++ b/inst/workflows/pr-close-signal.yaml
@@ -16,7 +16,7 @@ jobs:
           mkdir -p ./pr
           printf ${{ github.event.number }} > ./pr/NUM
       - name: Upload Diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ./pr

--- a/inst/workflows/pr-comment.yaml
+++ b/inst/workflows/pr-comment.yaml
@@ -82,7 +82,7 @@ jobs:
       contents: write
     steps:
       - name: 'Checkout md outputs'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: md-outputs
           path: built

--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Upload PR number"
         id: upload
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ${{ github.workspace }}/NR

--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: "Checkout Lesson"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up R"
         uses: r-lib/actions/setup-r@v2

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -43,7 +43,7 @@ jobs:
       needed: ${{ steps.renv.outputs.exists }}
     steps:
       - name: "Checkout Lesson"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: renv
         run: |
           if [[ -d renv ]]; then
@@ -76,7 +76,7 @@ jobs:
     steps:
 
       - name: "Checkout Lesson"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up R"
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
This should fix some of the Node16 deprecation warnings we see in lessons. This won't solve all of them but the rest is addressed by https://github.com/carpentries/actions/pull/91.