### PR TITLE
Add template CFF

### DIFF
--- a/R/create_lesson.R
+++ b/R/create_lesson.R
@@ -41,6 +41,7 @@ create_lesson <- function(path, name = fs::path_file(path), rmd = TRUE, rstudio 
   copy_template("conduct", path, "CODE_OF_CONDUCT.md")
   copy_template("license", path, "LICENSE.md")
   copy_template("contributing", path, "CONTRIBUTING.md")
+  copy_template("citation", path, "CITATION.cff")
   copy_template("setup", fs::path(path, "learners"), "setup.md")
   copy_template("index", path, "index.md")
   copy_template("links", path, "links.md")

--- a/R/template.R
+++ b/R/template.R
@@ -58,6 +58,10 @@ template_links <- generate_template_function("links")
 
 #' @rdname template
 #' @export
+template_citation <- generate_template_function("citation")
+
+#' @rdname template
+#' @export
 template_config <- generate_template_function("config")
 
 #' @rdname template

--- a/inst/templates/citation-template.txt
+++ b/inst/templates/citation-template.txt
@@ -1,0 +1,22 @@
+# This template CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to replace its contents
+# with information about your lesson.
+# Remember to update this file periodically, 
+# ensuring that the author list and other fields remain accurate.
+
+cff-version: 1.2.0
+title: FIXME
+message: >-
+  Please cite this lesson using the information in this file
+  when you refer to it in publications, and/or if you
+  re-use, adapt, or expand on the content in your own
+  training material.
+type: dataset
+authors:
+  - given-names: FIXME
+    family-names: FIXME
+abstract: >-
+  FIXME Replace this with a short abstract describing the
+  lesson, e.g. its target audience and main intended
+  learning objectives.
+license: CC-BY-4.0

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -61,6 +61,7 @@ test_that("All template files exist", {
   expect_true(fs::file_exists(fs::path(tmp, "episodes", "introduction.Rmd")))
   expect_true(fs::file_exists(fs::path(tmp, ".gitignore")))
   expect_true(fs::file_exists(fs::path(tmp, paste0(basename(tmp), ".Rproj"))))
+  expect_true(fs::file_exists(fs::path(tmp, "CITATION.cff")))
 })
 
 test_that("Templated files are correct", {
@@ -73,6 +74,10 @@ test_that("Templated files are correct", {
   expect_setequal(
     readLines(fs::path(tmp, "episodes", "introduction.Rmd")),
     strsplit(expected, "\n")[[1]]
+  )
+  expect_setequal(
+    readLines(fs::path(tmp, "CITATION.cff")),
+    readLines(template_citation())
   )
 
 })

--- a/tests/testthat/test-create_lesson.R
+++ b/tests/testthat/test-create_lesson.R
@@ -8,7 +8,6 @@
 }
 
 test_that("lessons can be created in empty directories", {
-
   expect_false(fs::dir_exists(tmp))
   suppressMessages({capture.output({
     res <- create_lesson(tmp, name = "BRAND NEW LESSON", rstudio = TRUE, open = TRUE)
@@ -26,7 +25,6 @@ test_that("lessons are NOT initialized with a 'master' branch", {
   expect_false(gert::git_branch_exists("master", repo = tmp))
   # enforce that our new branch matches the user's default branch (or main)
   expect_true(gert::git_branch(tmp) == sandpaper:::get_default_branch())
-
 })
 
 test_that("check_lesson() passes muster on new lessons", {
@@ -79,7 +77,6 @@ test_that("Templated files are correct", {
     readLines(fs::path(tmp, "CITATION.cff")),
     readLines(template_citation())
   )
-
 })
 
 test_that("Lesson configuration is correctly provisioned", {
@@ -127,7 +124,6 @@ test_that("We have a git repo that's correctly configured", {
 })
 
 cli::test_that_cli("Destruction of the .gitignore file renders the lesson incorrect", {
-
   if (fs::file_exists(gi <- fs::path(tmp, ".gitignore"))) fs::file_delete(gi)
   expect_snapshot({
     expect_error(
@@ -138,7 +134,6 @@ cli::test_that_cli("Destruction of the .gitignore file renders the lesson incorr
 })
 
 test_that("lessons cannot be created in directories that are occupied", {
-
   skip("needs evaluation, but not critical infrastructure tool")
   tmpdir <- fs::file_temp()
   fs::dir_create(tmpdir)
@@ -153,5 +148,4 @@ test_that("lessons cannot be created in directories that are occupied", {
 
   # This should fail
   expect_error(create_lesson(tmp, open = FALSE), "lesson-example is not an empty directory.")
-
 })


### PR DESCRIPTION
Closes #508 

Adds a template `CITATION.cff` file to be included in new lessons initialised with `create_lesson()`. I had a go at writing tests, and would love feedback on what I missed and how I could have done it better.

