### PR TITLE
Remove windows-latest 3.6 check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,8 +28,11 @@ jobs:
           - {os: macOS-latest, cache: '~/Library/Application Support/renv', r: 'release'}
 
           - {os: windows-latest, r: 'release'}
+          
           # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, cache: '~\AppData\Local\renv', r: '3.6'}
+          # As of 2024-06, downlit now requires R >4.0.0 so this should be deprecated.
+          # - {os: windows-latest, cache: '~\AppData\Local\renv', r: '3.6'}
+          
           # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
 


### PR DESCRIPTION
downlit no longer supports R < 4.0.0 so we should remove this check and state that R 3.6 is unsupported.
