### PR TITLE
Temporary fix for h2 anchor duplication and associated tests

### DIFF
--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -143,14 +143,9 @@ add_anchors <- function(nodes, ids) {
       next
     }
 
+    # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
     # Insert anchor in first element of header
-    xml2::xml_add_child(heading, xml2::read_xml(anchor[[i]]))
-
-    # fix for pkgdown 2.1.0 now adding in anchors for <section> tags
-    # rename our workbench translated sections <workbench-section>
-    # this would require a lot more downstream work
-    # sections <- xml2::xml_parent(heading)
-    # xml2::xml_set_name(sections, "workbench-section")
+    # xml2::xml_add_child(heading, xml2::read_xml(anchor[[i]]))
   }
 }
 

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -78,14 +78,14 @@ test_that("local site build produces 404 page with relative links", {
 })
 
 
-test_that("Anchors for Keypoints are not missing", {
-  skip_if_not(rmarkdown::pandoc_available("2.11"))
-  html <- xml2::read_html(fs::path(sitepath, "introduction.html"))
-  anchor <- xml2::xml_find_first(html, ".//div[contains(@class, 'keypoints')]//h3/a")
-  expect_match(xml2::xml_attr(anchor, "href"), "[#]keypoints")
-  expect_match(xml2::xml_attr(anchor, "class"), "anchor")
-  expect_match(xml2::xml_attr(anchor, "aria-label"), "anchor")
-})
+# test_that("Anchors for Keypoints are not missing", {
+#   skip_if_not(rmarkdown::pandoc_available("2.11"))
+#   html <- xml2::read_html(fs::path(sitepath, "introduction.html"))
+#   anchor <- xml2::xml_find_first(html, ".//div[contains(@class, 'keypoints')]//h3/a")
+#   expect_match(xml2::xml_attr(anchor, "href"), "[#]keypoints")
+#   expect_match(xml2::xml_attr(anchor, "class"), "anchor")
+#   expect_match(xml2::xml_attr(anchor, "aria-label"), "anchor")
+# })
 
 
 test_that("aio page can be rebuilt", {

--- a/tests/testthat/test-utils-translate.R
+++ b/tests/testthat/test-utils-translate.R
@@ -231,23 +231,24 @@ test_that("Lessons can be translated with lang setting", {
     )
   )
 
-  # aria labels should be translated
-  aria_text <- c(
-    tr_src("varnish", "MainNavigation"),
-    tr_src("varnish", "ToggleNavigation"),
-    tr_src("varnish", "ToggleDarkMode"),
-    tr_src("varnish", "Search"),
-    tr_src("varnish", "SearchButton"),
-    tr_src("varnish", "LessonProgress"),
-    tr_src("varnish", "CloseMenu"),
-    tr_src("varnish", "NextChapter"),
-    tr_src("computed", "Anchor"),
-    tr_src("varnish", "BackToTop")
-  )
-  aria_labels <- xml2::xml_find_all(xml, ".//@aria-label")
-  iaria_labels <- xml2::xml_find_all(instruct, ".//@aria-label")
-  expect_set_translated(aria_labels, aria_text)
-  expect_set_translated(iaria_labels, aria_text)
+# temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
+#   # aria labels should be translated
+#   aria_text <- c(
+#     tr_src("varnish", "MainNavigation"),
+#     tr_src("varnish", "ToggleNavigation"),
+#     tr_src("varnish", "ToggleDarkMode"),
+#     tr_src("varnish", "Search"),
+#     tr_src("varnish", "SearchButton"),
+#     tr_src("varnish", "LessonProgress"),
+#     tr_src("varnish", "CloseMenu"),
+#     tr_src("varnish", "NextChapter"),
+#     # tr_src("computed", "Anchor"),
+#     tr_src("varnish", "BackToTop")
+#   )
+#   aria_labels <- xml2::xml_find_all(xml, ".//@aria-label[@class!='anchor']")
+#   iaria_labels <- xml2::xml_find_all(instruct, ".//@aria-label[@class!='anchor']")
+#   expect_set_translated(aria_labels, aria_text)
+#   expect_set_translated(iaria_labels, aria_text)
 
 
   # GENERATED PAGES ------------------------------------------------
@@ -310,21 +311,22 @@ test_that("Lessons can be translated with lang setting", {
     )
   )
 
-  # aria labels should be translated
-  aria_text <- c(
-    tr_src("varnish", "MainNavigation"),
-    tr_src("varnish", "ToggleNavigation"),
-    tr_src("varnish", "ToggleDarkMode"),
-    tr_src("varnish", "Search"),
-    tr_src("varnish", "SearchButton"),
-    tr_src("varnish", "LessonProgress"),
-    tr_src("varnish", "CloseMenu"),
-    tr_src("varnish", "PreviousAndNext"),
-    tr_src("computed", "Anchor"),
-    tr_src("varnish", "BackToTop")
-  )
-  aria_labels <- xml2::xml_find_all(xml, ".//@aria-label")
-  expect_set_translated(aria_labels, aria_text)
+# temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
+#   # aria labels should be translated
+#   aria_text <- c(
+#     tr_src("varnish", "MainNavigation"),
+#     tr_src("varnish", "ToggleNavigation"),
+#     tr_src("varnish", "ToggleDarkMode"),
+#     tr_src("varnish", "Search"),
+#     tr_src("varnish", "SearchButton"),
+#     tr_src("varnish", "LessonProgress"),
+#     tr_src("varnish", "CloseMenu"),
+#     tr_src("varnish", "PreviousAndNext"),
+#     # tr_src("computed", "Anchor"),
+#     tr_src("varnish", "BackToTop")
+#   )
+#   aria_labels <- xml2::xml_find_all(xml, ".//@aria-label[@class!='anchor']")
+#   expect_set_translated(aria_labels, aria_text)
 
   # overview, objectives, and questions
   overview_card <- xml2::xml_find_first(xml, ".//div[@class='overview card']")

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -58,7 +58,10 @@ test_that("(#556) (#454) callout are processed correctly", {
   headings <- xml2::xml_find_all(html_test, ".//h3")
   callouts <- xml2::xml_find_all(html_test,
     ".//div[starts-with(@class, 'callout ')]")
-  expect_length(anchors, 2)
+
+  # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
+  # expect_length(anchors, 2)
+
   expect_length(callouts, 2)
   expect_length(headings, 2)
   # headings should not have IDS
@@ -68,12 +71,15 @@ test_that("(#556) (#454) callout are processed correctly", {
   # The IDs should be what we expect
   ids <- xml2::xml_attr(callouts, "id")
   expect_equal(ids, c("discussion1", "wait-what"))
+
+  # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
   # The IDs should match the anchors
-  expect_equal(paste0("#", ids), xml2::xml_attr(anchors, "href"))
+  # expect_equal(paste0("#", ids), xml2::xml_attr(anchors, "href"))
+
   # The headings should match what we expect
   # (https://github.com/carpentries/sandpaper/issues/556)
   htext <- xml2::xml_find_all(headings, ".//text()")
-  expect_equal(xml2::xml_text(htext), 
+  expect_equal(xml2::xml_text(htext),
     c("Challenge (", "this is code", ")", "Wait what?"))
 })
 
@@ -127,9 +133,9 @@ test_that("code block languages are in the correct order", {
   </code>
   </pre>
   </div>'
-  
+
   nodes <- xml2::read_html(html)
-  
+
   # ABSENCE TESTS -------------------------------------------
   # By default, there are no h3 headings
   expect_length(xml2::xml_find_all(nodes, ".//h3"), 0L)
@@ -137,9 +143,9 @@ test_that("code block languages are in the correct order", {
   expect_length(xml2::xml_find_all(nodes, xpath_codewrap), 0L)
   xpath_pre_tabindex <- ".//pre[@tabindex]"
   expect_length(xml2::xml_find_all(nodes, xpath_pre_tabindex), 0L)
-  
+
   fix_codeblocks(nodes)
-  
+
   # PRESENCE TESTS ------------------------------------------
   expect_length(xml2::xml_find_all(nodes, ".//h3"), 2L)
   expect_length(xml2::xml_find_all(nodes, xpath_codewrap), 2L)


### PR DESCRIPTION
PR attempts to temporarily fix https://github.com/r-lib/pkgdown/issues/2737 by removing our added (translated) anchors.