### PR TITLE
Bug fix: overwrite existing artifact in `pr-receive` workflow

### DIFF
--- a/inst/workflows/pr-receive.yaml
+++ b/inst/workflows/pr-receive.yaml
@@ -111,6 +111,7 @@ jobs:
         with:
           name: pr
           path: ${{ env.PR }}
+          overwrite: true
 
       - name: "Upload Diff"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Addresses an error in the `pr-receive` workflow, where the `Build markdown source files if valid` step would fail with

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

This error was introduced when updating the `upload-artifact` action to `v4` in `sandpaper 0.16.6`. See the [breaking changes](https://github.com/actions/upload-artifact#breaking-changes) for `upload-artifacts@v4`.

Tested this on a bunch of PRs at https://github.com/UCL-ARC/r-amr-epidemiology/actions/workflows/pr-receive.yaml.
