### PR TITLE
Pin ubuntu to 22.04 due to R being not installed by default in 24.04

### DIFF
--- a/inst/workflows/sandpaper-main.yaml
+++ b/inst/workflows/sandpaper-main.yaml
@@ -21,7 +21,10 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+
+    # 2024-10-01: ubuntu-latest is now 24.04 and R is not installed by default in the runner image
+    # pin to 22.04 for now
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
Provides a workaround for #605 to pin ubuntu to 22.04. `ubuntu-latest` is now 24.04 which does not include R by default any more (for now): https://github.com/actions/runner-images/issues/9848