### PR TITLE
[WIP] Automated processing and page generation of glosario links in lessons

### DIFF
--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -19,6 +19,8 @@
 #'   sidebar. The current episode will be replaced with an index of all the
 #'   chapters in the episode.
 #' @param date the date the episode was last built.
+#' @param glosario a dictionary of terms read in from Glosario glossary.yaml
+#'   on Github. Defaults to NULL.
 #' @return `TRUE` if the page was successful, `FALSE` otherwise.
 #' @export
 #' @note this function is for internal use, but exported for those who know what
@@ -72,12 +74,13 @@
 build_episode_html <- function(path_md, path_src = NULL,
                                page_back = "index.md", page_forward = "index.md",
                                pkg, quiet = FALSE, page_progress = NULL,
-                               sidebar = NULL, date = NULL) {
+                               sidebar = NULL, date = NULL, glosario = NULL) {
   home <- get_source_path() %||% root_path(path_md)
   this_lesson(home)
   page_globals <- setup_page_globals()
   slug <- get_slug(path_md)
-  body <- render_html(path_md, quiet = quiet)
+  body <- render_html(path_md, quiet = quiet, glosario = glosario)
+
   if (body == "") {
     # if there is nothing in the page then we build nothing.
     return(NULL)

--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -46,6 +46,8 @@ render_glosario_links <- function(path_in, glosario = NULL, quiet = FALSE) {
     # overwrite the file with the new content
     writeLines(glosarioed_content, path_in)
   }
+
+  # the processed file path for subsequent lesson processing as usual
   invisible(path_in)
 }
 

--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -1,0 +1,251 @@
+read_glosario_yaml <- function(glosario) {
+  if (is.null(glosario) || glosario == FALSE) {
+    return(NULL)
+  }
+  else {
+    # Load the glossary YAML file from the GitHub repository
+    glosario_url <- "https://raw.githubusercontent.com/carpentries/glosario/main/glossary.yml"
+    glosario_response <- httr::GET(glosario_url)
+
+    if (httr::status_code(glosario_response) == 200) {
+      glosario <- yaml::yaml.load(httr::content(glosario_response, as = "text"))
+      return(glosario)
+    } else {
+      return(NULL)
+    }
+  }
+}
+
+# Function to generate the link if the term exists in the glossary
+create_glosario_link <- function(term, slugs) {
+  if (term %in% slugs) {
+    url <- paste0("https://glosario.carpentries.org/", this_metadata$get()[["lang"]], "/#", term)
+    return(paste0("[^", term, "^](", url, ")"))
+  } else {
+    return(term)  # Return the term as is if not found in the glossary
+  }
+}
+
+render_glosario_links <- function(path_in, glosario = NULL, quiet = FALSE) {
+  if (!is.null(glosario)) {
+    content <- readLines(path_in)
+
+    slugs <- lapply(glosario, function(x) x$slug)
+    glos_pattern <- "\\{\\{\\s*glosario\\.(\\w+)\\s*\\}\\}"
+
+    # replace {{ glosario.term }} placeholders with glossary link URLs
+    glosarioed_content <- stringr::str_replace_all(
+        content,
+        pattern = glos_pattern,
+        replacement = function(match) {
+          term <- stringr::str_match(match, glos_pattern)[[2]]
+          create_glosario_link(term, slugs)
+        }
+      )
+
+    # overwrite the file with the new content
+    writeLines(glosarioed_content, path_in)
+  }
+  invisible(path_in)
+}
+
+#' @rdname build_glossary
+build_glossary <- function(pkg, pages = NULL, quiet = FALSE) {
+  build_glossary_page(
+      pkg = pkg,
+      pages = pages,
+      # title = tr_computed("Glossary"),
+      slug = "glossary",
+      prefix = TRUE,
+      quiet = quiet,
+  )
+}
+
+#' Build a page for aggregating glosario elements
+#'
+#' @inheritParams provision_agg_page
+#' @param pages output from the function [read_all_html()]: a nested list of
+#'   `xml_document` objects representing episodes in the lesson
+#' @param aggregate a selector for the lesson content you want to aggregate.
+#'   The default is "section", which will aggregate all sections, but nothing
+#'   outside of the sections. To grab everything in the page, use "*"
+#' @param append a selector for the section of the page where the aggregate data
+#'   should be placed. This defaults to "self::node()", which indicates that the
+#'   entire page should be appended.
+#' @param prefix flag to add a prefix for the aggregated sections. Defaults to
+#'   `FALSE`.
+#' @param quiet if `TRUE`, no messages will be emitted. If FALSE, pkgdown will
+#'   report creation of the temporary file.
+#' @return NULL, invisibly. This is called for its side-effect
+#'
+#' @details
+#'
+#' Building an aggregate page is very much akin to copy/paste---you take the
+#' same elements across several pages and paste them into one large page. We can
+#' do this programmatically by using XPath to extract nodes from pages and add
+#' them into the document.
+#'
+#' To customise the page, we need a few things:
+#'
+#' 1. a title
+#' 2. a slug
+#' 3. a method to prepare and insert the extracted content (e.g. [make_aio_section()])
+#' @note
+#' This function assumes that you have already built all the episodes of your
+#' lesson.
+#'
+#' @keywords internal
+#' @rdname build_agg
+#' @examples
+#' if (FALSE) {
+#'   # build_glossary_page() assumes that your lesson has been built and takes in a
+#'   # pkgdown object, which can be created from the `site/` folder in your
+#'   # lesson.
+#'   lsn <- "/path/to/my/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'
+#'   htmls <- read_all_html(pkg$dst_path)
+#'   build_glossary_page(pkg, htmls, quiet = FALSE)
+#'   build_keypoints(pkg, htmls, quiet = FALSE)
+#' }
+build_glossary_page <- function(pkg, pages, title = NULL, slug = NULL, append = "self::node()", prefix = FALSE, quiet = FALSE) {
+  path <- get_source_path() %||% root_path(pkg$src_path)
+  out_path <- pkg$dst_path
+  this_lesson(path)
+
+  new_content <- append == "self::node()" || append == "self::*"
+  agg <- provision_agg_page(pkg, title = "Glosario Links", slug = slug, new = new_content)
+
+  agg_sect <- xml2::xml_find_first(agg$learner, ".//section[@id='glossary']")
+  agg_ul <- xml2::xml_add_child(agg_sect, "ul", id="glosario-list")
+
+  the_episodes <- .resources$get()[["episodes"]]
+  the_slugs <- get_slug(the_episodes)
+  the_slugs <- if (prefix) paste0(slug, "-", the_slugs) else the_slugs
+
+  # vector to hold all unique links from all episodes
+  glinks <- character()
+
+  for (episode in seq(the_episodes)) {
+    ep_learn <- ep_instruct <- the_episodes[episode]
+    ename <- the_slugs[episode]
+
+    if (!is.null(pages)) {
+      name <- if (prefix) sub(paste0("^", slug, "-"), "", ename) else ename
+      ep_learn <- pages$learner[[name]]
+      ep_instruct <- pages$instructor[[name]]
+    }
+    ep_title <- as.character(xml2::xml_contents(get_content(ep_learn, ".//h1")))
+
+    names(ename) <- paste(ep_title, collapse = "")
+    ep_learn <- get_glossary_content(ep_learn, content = "self::node()", pkg = pkg)
+    ep_learn_glinks <- get_glossary_links(ep_learn)
+
+    ep_instruct <- get_glossary_content(ep_instruct, content = "self::node()", pkg = pkg, instructor = TRUE)
+    ep_instruct_glinks <- get_glossary_links(ep_instruct)
+
+    # get unique set of links from both learner and instructor
+    ep_glinks <- unique(c(ep_learn_glinks, ep_instruct_glinks))
+
+    # append unique episode glinks to global glinks
+    glinks <- unique(c(ep_glinks, glinks))
+  }
+
+  glinks <- sort(glinks)
+
+  # Iterate over glinks to create HTML elements
+  for (link in glinks) {
+    # remove everything before the last #
+    term <- stringr::str_extract(link, "#(.*)")
+    term <- str_replace(term, "#", "")
+    agg_li <- xml2::xml_add_child(agg_ul, "li")
+    xml2::xml_add_child(agg_li, "a", term, href = link)
+  }
+
+  glos_out <- fs::path(out_path, as_html(slug))
+  report <- "Writing '{.file {glos_out}}'"
+  out <- fs::path_rel(glos_out, pkg$dst_path)
+  if (!quiet) cli::cli_text(report)
+  writeLines(as.character(agg$learner), glos_out)
+}
+
+get_glossary_links <- function(episode) {
+  lang <- this_metadata$get()[["lang"]]
+  links <- xml2::xml_find_all(episode, ".//a")
+  links <- links[xml2::xml_attr(links, "href") %>%
+    stringr::str_detect("^https://glosario.carpentries.org/")]
+
+  clean_links <- character()
+  for (link in links) {
+    href <- xml2::xml_attr(link, "href")
+    xml2::xml_attr(link, "href") <- stringr::str_replace_all(href, "en/", lang)
+    clean_links <- c(clean_links, href)
+  }
+  invisible(clean_links)
+}
+
+#' Get content to process into the glossary
+#'
+#' @param episode an object of class `xml_document`, a path to a markdown or
+#'   html file of an episode.
+#' @inheritParams build_aio
+#' @param content an XPath fragment. defaults to "*"
+#' @param label if `TRUE`, elements will be named by their ids. This is best
+#'   used when content = "section".
+#' @param instructor if `TRUE`, the instructor version of the episode is read,
+#'   defaults to `FALSE`. This has no effect if the episode is an `xml_document`.
+#'
+#' @details
+#' The contents of the lesson are contained in the following templating cascade:
+#'
+#' ```html
+#' <body>
+#'   <div class='container'>
+#'     <div class='row'>
+#'       <div class='[...] primary-content'>
+#'         <main>
+#'           <div class='[...] lesson-content'>
+#'             CONTENT HERE
+#' ```
+#'
+#' This function will extract the content from the episode without the templating.
+#'
+#' @keywords internal
+#' @examples
+#' if (FALSE) {
+#'   lsn <- "/path/to/lesson"
+#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
+#'
+#'   # for AiO pages, this will return only the top-level sections:
+#'   get_content("aio", content = "section", label = TRUE, pkg = pkg)
+#'
+#'   # for episode pages, this will return everything that's not template
+#'   get_content("01-introduction", pkg = pkg)
+#'
+#'   # for things that are within lessons but we don't know their exact location,
+#'   # we can prefix a `/` to double up the slash, which will produce
+#' }
+get_glossary_content <- function(
+    episode, content = "*", label = FALSE, pkg = NULL,
+    instructor = FALSE) {
+  if (!inherits(episode, "xml_document")) {
+    if (instructor) {
+      path <- fs::path(pkg$dst_path, "instructor", as_html(episode))
+    } else {
+      path <- fs::path(pkg$dst_path, as_html(episode))
+    }
+    episode <- xml2::read_html(path)
+  }
+  XPath <- ".//main/div[contains(@class, 'lesson-content')]/{content}"
+  res <- xml2::xml_find_all(episode, glue::glue(XPath))
+  if (label) {
+    names(res) <- xml2::xml_attr(res, "id")
+  }
+  res
+}
+
+get_title <- function(doc) {
+  xml2::xml_find_first(doc, ".//h1")
+}
+
+# nocov end

--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -22,7 +22,7 @@ create_glosario_link <- function(term, slugs) {
     url <- paste0("https://glosario.carpentries.org/", this_metadata$get()[["lang"]], "/#", term)
     return(paste0("[^", term, "^](", url, ")"))
   } else {
-    return(term)  # Return the term as is if not found in the glossary
+    return(term)  # Return the term as-is if not found in the glossary
   }
 }
 
@@ -56,46 +56,39 @@ build_glossary <- function(pkg, pages = NULL, quiet = FALSE) {
       pages = pages,
       # title = tr_computed("Glossary"),
       slug = "glossary",
-      prefix = TRUE,
       quiet = quiet,
   )
 }
 
-#' Build a page for aggregating glosario elements
+#' Build a page for aggregating glosario links found in lesson elements
 #'
 #' @inheritParams provision_agg_page
 #' @param pages output from the function [read_all_html()]: a nested list of
 #'   `xml_document` objects representing episodes in the lesson
 #' @param aggregate a selector for the lesson content you want to aggregate.
-#'   The default is "section", which will aggregate all sections, but nothing
-#'   outside of the sections. To grab everything in the page, use "*"
+#'   The default is "*", which will aggregate links from all content.
+#'   To grab only links from sections, use "section".
 #' @param append a selector for the section of the page where the aggregate data
 #'   should be placed. This defaults to "self::node()", which indicates that the
 #'   entire page should be appended.
-#' @param prefix flag to add a prefix for the aggregated sections. Defaults to
-#'   `FALSE`.
 #' @param quiet if `TRUE`, no messages will be emitted. If FALSE, pkgdown will
 #'   report creation of the temporary file.
 #' @return NULL, invisibly. This is called for its side-effect
 #'
 #' @details
 #'
-#' Building an aggregate page is very much akin to copy/paste---you take the
-#' same elements across several pages and paste them into one large page. We can
-#' do this programmatically by using XPath to extract nodes from pages and add
-#' them into the document.
+#' We programmatically search through lesson content to find links that point to
+#' glosario terms. We then aggregate these links into a single page.
 #'
 #' To customise the page, we need a few things:
 #'
 #' 1. a title
 #' 2. a slug
-#' 3. a method to prepare and insert the extracted content (e.g. [make_aio_section()])
 #' @note
-#' This function assumes that you have already built all the episodes of your
-#' lesson.
+#' This function assumes that you have already built all the episodes of your lesson.
 #'
 #' @keywords internal
-#' @rdname build_agg
+#' @rdname build_glossary
 #' @examples
 #' if (FALSE) {
 #'   # build_glossary_page() assumes that your lesson has been built and takes in a
@@ -108,20 +101,18 @@ build_glossary <- function(pkg, pages = NULL, quiet = FALSE) {
 #'   build_glossary_page(pkg, htmls, quiet = FALSE)
 #'   build_keypoints(pkg, htmls, quiet = FALSE)
 #' }
-build_glossary_page <- function(pkg, pages, title = NULL, slug = NULL, append = "self::node()", prefix = FALSE, quiet = FALSE) {
+build_glossary_page <- function(pkg, pages, title = "Glosario Links", slug = NULL, aggregate = "*", append = "self::node()", quiet = FALSE) {
   path <- get_source_path() %||% root_path(pkg$src_path)
   out_path <- pkg$dst_path
   this_lesson(path)
 
-  new_content <- append == "self::node()" || append == "self::*"
-  agg <- provision_agg_page(pkg, title = "Glosario Links", slug = slug, new = new_content)
+  agg <- provision_agg_page(pkg, title = title, slug = slug, new = TRUE)
 
   agg_sect <- xml2::xml_find_first(agg$learner, ".//section[@id='glossary']")
   agg_ul <- xml2::xml_add_child(agg_sect, "ul", id="glosario-list")
 
   the_episodes <- .resources$get()[["episodes"]]
   the_slugs <- get_slug(the_episodes)
-  the_slugs <- if (prefix) paste0(slug, "-", the_slugs) else the_slugs
 
   # vector to hold all unique links from all episodes
   glinks <- character()
@@ -131,17 +122,16 @@ build_glossary_page <- function(pkg, pages, title = NULL, slug = NULL, append = 
     ename <- the_slugs[episode]
 
     if (!is.null(pages)) {
-      name <- if (prefix) sub(paste0("^", slug, "-"), "", ename) else ename
-      ep_learn <- pages$learner[[name]]
-      ep_instruct <- pages$instructor[[name]]
+      ep_learn <- pages$learner[[ename]]
+      ep_instruct <- pages$instructor[[ename]]
     }
     ep_title <- as.character(xml2::xml_contents(get_content(ep_learn, ".//h1")))
 
     names(ename) <- paste(ep_title, collapse = "")
-    ep_learn <- get_glossary_content(ep_learn, content = "self::node()", pkg = pkg)
+    ep_learn <- get_content(ep_learn, content = aggregate, pkg = pkg)
     ep_learn_glinks <- get_glossary_links(ep_learn)
 
-    ep_instruct <- get_glossary_content(ep_instruct, content = "self::node()", pkg = pkg, instructor = TRUE)
+    ep_instruct <- get_content(ep_instruct, content = aggregate, pkg = pkg, instructor = TRUE)
     ep_instruct_glinks <- get_glossary_links(ep_instruct)
 
     # get unique set of links from both learner and instructor
@@ -157,7 +147,7 @@ build_glossary_page <- function(pkg, pages, title = NULL, slug = NULL, append = 
   for (link in glinks) {
     # remove everything before the last #
     term <- stringr::str_extract(link, "#(.*)")
-    term <- str_replace(term, "#", "")
+    term <- stringr::str_replace(term, "#", "")
     agg_li <- xml2::xml_add_child(agg_ul, "li")
     xml2::xml_add_child(agg_li, "a", term, href = link)
   }
@@ -182,66 +172,6 @@ get_glossary_links <- function(episode) {
     clean_links <- c(clean_links, href)
   }
   invisible(clean_links)
-}
-
-#' Get content to process into the glossary
-#'
-#' @param episode an object of class `xml_document`, a path to a markdown or
-#'   html file of an episode.
-#' @inheritParams build_aio
-#' @param content an XPath fragment. defaults to "*"
-#' @param label if `TRUE`, elements will be named by their ids. This is best
-#'   used when content = "section".
-#' @param instructor if `TRUE`, the instructor version of the episode is read,
-#'   defaults to `FALSE`. This has no effect if the episode is an `xml_document`.
-#'
-#' @details
-#' The contents of the lesson are contained in the following templating cascade:
-#'
-#' ```html
-#' <body>
-#'   <div class='container'>
-#'     <div class='row'>
-#'       <div class='[...] primary-content'>
-#'         <main>
-#'           <div class='[...] lesson-content'>
-#'             CONTENT HERE
-#' ```
-#'
-#' This function will extract the content from the episode without the templating.
-#'
-#' @keywords internal
-#' @examples
-#' if (FALSE) {
-#'   lsn <- "/path/to/lesson"
-#'   pkg <- pkgdown::as_pkgdown(fs::path(lsn, "site"))
-#'
-#'   # for AiO pages, this will return only the top-level sections:
-#'   get_content("aio", content = "section", label = TRUE, pkg = pkg)
-#'
-#'   # for episode pages, this will return everything that's not template
-#'   get_content("01-introduction", pkg = pkg)
-#'
-#'   # for things that are within lessons but we don't know their exact location,
-#'   # we can prefix a `/` to double up the slash, which will produce
-#' }
-get_glossary_content <- function(
-    episode, content = "*", label = FALSE, pkg = NULL,
-    instructor = FALSE) {
-  if (!inherits(episode, "xml_document")) {
-    if (instructor) {
-      path <- fs::path(pkg$dst_path, "instructor", as_html(episode))
-    } else {
-      path <- fs::path(pkg$dst_path, as_html(episode))
-    }
-    episode <- xml2::read_html(path)
-  }
-  XPath <- ".//main/div[contains(@class, 'lesson-content')]/{content}"
-  res <- xml2::xml_find_all(episode, glue::glue(XPath))
-  if (label) {
-    names(res) <- xml2::xml_attr(res, "id")
-  }
-  res
 }
 
 get_title <- function(doc) {

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -103,7 +103,8 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
       page_progress = progress,
       date          = db$date[i],
       pkg           = pkg,
-      quiet         = quiet
+      quiet         = quiet,
+      glosario      = this_metadata$get()[["glosario"]]
     )
   }
   # if (rebuild_template) template_check$set()

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -157,6 +157,9 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
 
     describe_progress("Creating Images page", quiet = quiet)
     build_images(pkg, pages = html_pages, quiet = quiet)
+
+    describe_progress("Indexing Glosario links", quiet = quiet)
+    build_glossary(pkg, pages = html_pages, quiet = quiet)
   }
   describe_progress("Creating Instructor Notes", quiet = quiet)
   build_instructor_notes(pkg, pages = html_pages, built = built, quiet = quiet)

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -41,7 +41,7 @@
 #' lf <- paste0("--lua-filter=", lua)
 #' cat(sandpaper:::render_html(tmp, lf))
 #' }
-render_html <- function(path_in, ..., quiet = FALSE) {
+render_html <- function(path_in, ..., quiet = FALSE, glosario = NULL) {
   htm <- tempfile(fileext = ".html")
   on.exit(unlink(htm), add = TRUE)
   links <- getOption("sandpaper.links")
@@ -57,6 +57,13 @@ render_html <- function(path_in, ..., quiet = FALSE) {
     path_in <- tmpin
     on.exit(unlink(tmpin), add = TRUE)
   }
+
+  if (!is.null(glosario)) {
+    # if we have a glossary, then we need to replace the glossary term placeholders
+    # with whisker.replace
+    path_in <- render_glosario_links(path_in, glosario = glosario, quiet = quiet)
+  }
+
   args <- construct_pandoc_args(path_in, output = htm, to = "html", ...)
   sho <- !(quiet || identical(Sys.getenv("TESTTHAT"), "true"))
   # Ensure we use the _loaded version_ of pandoc in case folks are using

--- a/R/utils-metadata.R
+++ b/R/utils-metadata.R
@@ -48,8 +48,7 @@ initialise_metadata <- function(path = ".") {
   this_metadata$set(c("date", "modified"), format(Sys.Date(), "%F"))
   this_metadata$set(c("date", "published"), format(Sys.Date(), "%F"))
   this_metadata$set("citation", path_citation(path))
+  this_metadata$set("glosario", read_glosario_yaml(cfg$glosario))
 
   this_metadata$set("analytics", cfg$analytics)
 }
-
-


### PR DESCRIPTION
## Implementation description

This PR is a work in progress to implement a core part of the Mellon Foundation grant to the Carpentries to automatically generate glossary pages in lessons from links to Glosario terms.

### Configuration

Firstly, to enable this behaviour, the following line needs to be added to a lesson's config.yaml:

`glosario: true`

### Lesson content

For example, the spreadsheet-ecology-lesson contains the following markdown:

```
The most common mistake made is treating spreadsheet programs like lab notebooks, that is, relying on context, 
notes in the margin, spatial layout of data and fields to convey information. As humans, we can (usually) interpret 
these things, but computers don't view information the same way, and unless we explain to the computer what 
every single thing means (and that can be hard!), it will not be able to see how our data fits together.

Using the power of computers, we can manage and analyze data in much more effective and faster ways, but to 
use that power, we have to set up our data for the computer to be able to understand it (and computers are very literal).
```

Secondly, a lesson maintainer/contributor will add placeholders into the main content of lessons that sandpaper will subsequently process. Sandpaper understands links to Glosario terms in two ways, either a template-style term, or a hard link to the term page, i.e.:
- `{{ glosario.<term>}}`
- `[<term>](https://glosario.carpentries.org/en/#<term>)`

### Example output

In the first example, to add a glosario link to the term `data structure` at the URL `https://glosario.carpentries.org/en/#data_structure`, the markdown becomes:

```
The most common mistake made is treating spreadsheet programs like lab notebooks, that is, relying on context, 
notes in the margin, spatial layout of data and fields to convey information. As humans, we can (usually) interpret 
these things, but computers don't view information the same way, and unless we explain to the computer what 
every single thing means (and that can be hard!), it will not be able to see how our data fits together. This is called 
the data structure {{ glosario.data_structure }}.
```

Similarly, to add a link using the second example:

```
Using the power of computers, we can manage and analyze data in much more effective and faster ways, but to 
use that power, we have to set up our data for the computer to be able to understand it 
(and computers are very [literal](https://glosario.carpentries.org/en/#literal)).
```

Once the lesson is built with `sandpaper::serve()`, this will produce the following output:

![{7E3AE97A-968F-4F1B-B17E-14D265F322FF}](https://github.com/user-attachments/assets/6540da64-8176-47f8-b7f2-8bb125416e44)

In the first example, `{{ glosario.data_structure }}` adds a `data_structure` link as a superscript inline. In the second example, it looks more like a typical markdown link.

In either case, sandpaper will find these links and add them to a global page in your lesson called `glossary.html`:
![{F167F923-1821-4F1A-844F-0A86D1553F77}](https://github.com/user-attachments/assets/67035320-7eee-4f48-982d-61307acccc0d)

## Things left to do

- Replace the current `reference.md#glossary` implementation, or add the glosario links to the same page?
- Tests!