### PR TITLE
Adding Caution Callout

### DIFF
--- a/R/utils-translate.R
+++ b/R/utils-translate.R
@@ -158,6 +158,7 @@ establish_translation_vars <- function() {
       Checklist   = tr_("Checklist"),
       Discussion  = tr_("Discussion"),
       Testimonial = tr_("Testimonial"),
+      Caution = tr_("Caution"),
       Keypoints   = varnish$KeyPoints,
       # Accordions -----------------------------------------------------------
       "Show me the solution" = tr_("Show me the solution"),

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -11,6 +11,7 @@ end
 
 local blocks = {
   ["callout"] = "bell",
+  ["caution"] = "alert-triangle",
   ["objectives"] = "none",
   ["challenge"] = "zap",
   ["prereq"] = "check",
@@ -28,6 +29,7 @@ local blocks = {
 
 local block_counts = {
   ["callout"] = 0,
+  ["caution"] = 0,
   ["objectives"] = 0,
   ["challenge"] = 0,
   ["prereq"] = 0,
@@ -188,6 +190,10 @@ local button_headings = {
   <h4 class="accordion-header" id="heading{{id}}">
   {{title}}
   </h4>]],
+  ["caution"] = [[
+    <h4 class="accordion-header" id="heading{{id}}">
+    {{title}}
+    </h4>]],
   ["hint"] = [[
   <h4 class="accordion-header" id="heading{{id}}">
   {{title}}

--- a/po/R-de.po
+++ b/po/R-de.po
@@ -370,3 +370,7 @@ msgstr "Bild {i} von {n}: {sQuote(txt)}"
 #: utils-translate.R:177
 msgid "Finish"
 msgstr "Fertig"
+
+#: utils-translate.R:178
+msgid "Caution"
+msgstr "Vorsicht"

--- a/po/R-es.po
+++ b/po/R-es.po
@@ -372,5 +372,9 @@ msgstr "Imagen {i} de {n}: {sQuote(txt)}"
 msgid "Finish"
 msgstr "Final"
 
+#: utils-translate.R:178
+msgid "Caution"
+msgstr "Precaución"
+
 #~ msgid "Search"
 #~ msgstr "Buscar"

--- a/po/R-fr.po
+++ b/po/R-fr.po
@@ -372,5 +372,9 @@ msgstr "Image {i} sur {n} : {sQuote(txt)}"
 msgid "Finish"
 msgstr "Terminer"
 
+#: utils-translate.R:178
+msgid "Caution"
+msgstr "Prudence"
+
 #~ msgid "Search"
 #~ msgstr "Recherche"

--- a/po/R-ja.po
+++ b/po/R-ja.po
@@ -375,5 +375,9 @@ msgstr "画像{i}/{n}: {sQuote(txt)}"
 msgid "Finish"
 msgstr "終わり"
 
+#: utils-translate.R:178
+msgid "Caution"
+msgstr "注意"
+
 #~ msgid "Search"
 #~ msgstr "検索"

--- a/po/R-sandpaper.pot
+++ b/po/R-sandpaper.pot
@@ -361,3 +361,7 @@ msgstr ""
 #: utils-translate.R:177
 msgid "Finish"
 msgstr ""
+
+#: utils-translate.R:178
+msgid "Caution"
+msgstr ""

--- a/po/R-uk.po
+++ b/po/R-uk.po
@@ -376,5 +376,9 @@ msgstr "Зображення {i} з {n}: {sQuote(txt)}"
 msgid "Finish"
 msgstr "Кінець"
 
+#: utils-translate.R:178
+msgid "Caution"
+msgstr "осторожность"
+
 #~ msgid "Search"
 #~ msgstr "Пошук"


### PR DESCRIPTION
When translating old modules, I noticed that the "Caution" callout is excluded in the new varnish/sandpaper packages.

If this was unintentional, I have prepared this PR to re-add this callout to Sandpaper, and have submitted a similar PR to Varnish as well.

This issue was also reported in the sandpaper-docs repo (https://github.com/carpentries/sandpaper-docs/issues/179)


