### PR TITLE
Fix config license change, add support for custom license_url

### DIFF
--- a/R/utils-metadata.R
+++ b/R/utils-metadata.R
@@ -36,6 +36,8 @@ initialise_metadata <- function(path = ".") {
     this_metadata$set("metadata_template", readLines(template_metadata()))
     this_metadata$set("pagetitle", cfg$title)
     this_metadata$set("keywords", cfg$keywords)
+    this_metadata$set("license", cfg$license)
+    this_metadata$set("license_url", cfg$license_url %||% "LICENSE.html")
     created <- cfg$created %||% tail(gert::git_log(max = 1e6, repo = path)$time, 1)
     this_metadata$set(c("date", "created"), format(as.Date(created), "%F"))
     # TODO: implement custom DESCRIPTION

--- a/R/utils-translate.R
+++ b/R/utils-translate.R
@@ -128,7 +128,7 @@ establish_translation_vars <- function() {
       Cite = tr_('Cite'),
       Contact = tr_('Contact'),
       About = tr_('About'),
-      MaterialsLicensedUnder = tr_('Materials licensed under {license} by the authors'),
+      MaterialsLicensedUnder = tr_('Materials licensed under <({license})> by the authors'),
       TemplateLicense = tr_('Template licensed under <(CC-BY 4.0)> by {template_authors}'),
       Carpentries = tr_('The Carpentries'),
       BuiltWith = tr_('Built with {sandpaper_link}, {pegboard_link}, and {varnish_link}'),
@@ -432,6 +432,7 @@ fill_translation_vars <- function(the_data) {
        icons = named_icons,
        template_authors = '<a href="https://carpentries.org/">The Carpentries</a>',
        license = the_data$license %||% "CC-BY 4.0",
+       license_url = the_data$license_url %||% "LICENSE.html",
        minutes = the_data$minutes %||% NULL,
        updated = the_data$updated %||% NULL
     )
@@ -462,6 +463,9 @@ fill_translation_vars <- function(the_data) {
         ),
         TemplateLicense = replace_link(the_string,
           href = "https://creativecommons.org/licenses/by-sa/4.0/"
+        ),
+        MaterialsLicensedUnder = replace_link(the_string,
+          href = dat$license_url
         ),
         SpanToTop = replace_html(the_string,
           open = '<span class="d-none d-sm-none d-md-none d-lg-none d-xl-block">',

--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -115,7 +115,9 @@ set_globals <- function(path) {
       sidebar = learner_sidebar,
       more = paste(learner$extras, collapse = ""),
       resources = paste(learner$resources, collapse = ""),
-      translate = tr_varnish()
+      translate = tr_varnish(),
+      license = this_metadata$get()[["license"]],
+      license_url = this_metadata$get()[["license_url"]]
     ), pkg_versions)
   )
   instructor_globals$set(key = NULL,
@@ -125,7 +127,9 @@ set_globals <- function(path) {
       sidebar = instructor_sidebar,
       more = paste(instructor$extras, collapse = ""),
       resources = paste(instructor$resources, collapse = ""),
-      translate = tr_varnish()
+      translate = tr_varnish(),
+      license = this_metadata$get()[["license"]],
+      license_url = this_metadata$get()[["license_url"]]
     ), pkg_versions)
   )
 }


### PR DESCRIPTION
This PR fixes #619 by:
- properly using the `license` key in a lesson `config.yaml`
- adding a new config option `license_url` so that users can supply custom license URLs

There are various `config.yaml` options:
- If the `license` is omitted completely, it will default to `CC-BY 4.0`, as before, and the footer license href will point to `LICENSE.html`
- If a `license` is supplied, but no `license_url` is supplied, the footer license href will point to `LICENSE.html`
- If a `license` is supplied and a `license_url` is supplied, both are used together