### PR TITLE
Fix website preview

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.16.10
+Version: 0.16.10.9000
 Authors@R: c(
     person(given = "Robert",
            family = "Davey",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# sandpaper (development version)
+
 # sandpaper 0.16.10 (2024-11-11)
 
 ## NEW FEATURES

--- a/R/build_site.R
+++ b/R/build_site.R
@@ -164,7 +164,7 @@ build_site <- function(path = ".", quiet = !interactive(), preview = TRUE, overr
   # At the end, a sitemap is created with our aggregated pages.
   build_sitemap(pkg$dst_path, paths = html_pages$paths, quiet = quiet)
 
-  pkgdown::preview_site(pkg, "/", preview = preview)
+  pkgdown::preview_site(pkg, preview = preview)
 
   if (!quiet) {
     dst <- fs::path_rel(path = pkg$dst_path, start = path)


### PR DESCRIPTION
following upstream changes in https://github.com/r-lib/pkgdown/pull/2650

Otherwise, we get the following error:

![image](https://github.com/user-attachments/assets/8eb972bd-b954-4ccc-854f-6f2de96ab344)

The change upstream is complex but the gist of what we're looking at here is that `fs::path()` was changed to `fs::path_abs()`. And `fs::path_abs()` doesn't work the same way as `path()` for file paths that already start with `/`.

``` r
fs::path("test", "/test.html")
#> test/test.html

fs::path_abs("/test.html", "test")
#> /test.html

fs::path_abs("test.html", "test")
#> /tmp/Rtmpyp0NA5/reprex-e4b47ac38bdd-hemp-urson/test/test.html
```

<sup>Created on 2024-12-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

@joelnitta reported a similar issue on slack. Joel, could you please try and see if this PR resolves your issue? :pray:
