### PR TITLE
Remove CI

### DIFF
--- a/inst/templates/license-template.txt
+++ b/inst/templates/license-template.txt
@@ -68,12 +68,11 @@ SOFTWARE.
 
 ## Trademark
 
-"The Carpentries", "Software Carpentry", "Data Carpentry", and "Library
-Carpentry" and their respective logos are registered trademarks of [Community
-Initiatives][ci].
+"The Carpentries", "Software Carpentry", "Library Carpentry", "Data Carpentry" and their respective logos are
+registered trademarks of [The Carpentries Inc][the-carpentries].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [mit-license]: https://opensource.org/licenses/mit-license.html
-[ci]: https://communityin.org/
 [osi]: https://opensource.org
+[the-carpentries]: https://carpentries.org/


### PR DESCRIPTION
Remove references to our former fiscal sponsor, Community Initiatives.

Related to carpentries/carpentries.org#364 and carpentries/carpentries.org#363.
