### PR TITLE
Update metadata-template.txt to correct schema.org type LearningResource

### DIFF
--- a/inst/templates/metadata-template.txt
+++ b/inst/templates/metadata-template.txt
@@ -1,7 +1,7 @@
 {{=<% %>=}}
 {
   "@context": "https://schema.org",
-  "@type": "TrainingMaterial",
+  "@type": "LearningResource",
   "@id": "<% url %>",
   "inLanguage": "<% lang %>",
   "dct:conformsTo": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",


### PR DESCRIPTION
As discussed in #481 (and previously in #236 and on Slack), the incorrect schema.org type was advised back in 2022. It should be `LearningResource` instead of `TrainingMaterial`. The confusion arose because the selected profile conforms to the `TrainingMaterial` Bioschemas type. 

This change will allow lessons to be correctly scraped by training catalogues built on the TeSS platform, such as ELIXIR TeSS, PaN-Training, SciLifeLab, DReSA, and others using valid schema.org. 