### PR TITLE
[WIP] Initial commit of updated workflows

### DIFF
--- a/inst/workflows/docker_build_deploy.yml
+++ b/inst/workflows/docker_build_deploy.yml
@@ -1,0 +1,139 @@
+name: "DOCKER Build and Deploy Site"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Who triggered this build?'
+        required: true
+        default: 'Maintainer (via GitHub)'
+      CACHE_VERSION:
+        description: 'Optional renv cache version override'
+        required: false
+        default: ''
+      reset:
+        description: 'Reset cached markdown files'
+        required: false
+        default: false
+        type: boolean
+jobs:
+  prepare:
+    name: "Grab renv.lock hash"
+    runs-on: ubuntu-latest
+    outputs:
+      renv-cache-hashsum: ${{ steps.set-hash.outputs.renv-cache-hashsum }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check if renv Exists
+        id: prep-check-renv
+        run: |
+          if [ -d "$GITHUB_WORKSPACE/renv" ]; then
+            echo "RENV_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "RENV_EXISTS=false" >> $GITHUB_ENV
+          fi
+
+      - name: Calculate renv hash
+        id: set-hash
+        if: env.RENV_EXISTS == 'true'
+        run: |
+          CACHE_VERSION_INPUT="${{ github.event.inputs.CACHE_VERSION }}"
+          if [ -z "$CACHE_VERSION_INPUT" ]; then
+            echo "renv-cache-hashsum=${{ hashFiles('renv/profiles/lesson-requirements/renv.lock') }}" >> $GITHUB_OUTPUT
+          else
+            echo "renv-cache-hashsum=$CACHE_VERSION_INPUT" >> $GITHUB_OUTPUT
+          fi
+
+  full-build:
+    name: "Build Full Site"
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      checks: write
+      contents: write
+      pages: write
+    container:
+      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      env:
+        WORKBENCH_PROFILE: "ci"
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        RENV_PATHS_ROOT: /home/rstudio/lesson/renv
+        RENV_VERSION: ${{ needs.prepare.outputs.renv-cache-hashsum }}
+      volumes:
+        - ${{ github.workspace }}:/home/rstudio/lesson
+      options: --cpus 1
+    steps:
+      - name: "Checkout Lesson"
+        uses: actions/checkout@v4
+
+      - name: Check if renv Exists
+        id: check-renv
+        run: |
+          if [ -d "/home/rstudio/lesson/renv" ]; then
+            echo "RENV_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "RENV_EXISTS=false" >> $GITHUB_ENV
+          fi
+
+      - name: "Grabbed renv.lock hash"
+        if: env.RENV_EXISTS == 'true'
+        run: echo "RENV_VERSION is $RENV_VERSION"
+
+      - name: Current env
+        run: env | sort
+
+      - name: Debugging Info
+        run: |
+          cd /home/rstudio/lesson
+          echo "Current Directory: $(pwd)"
+          ls -lah /home/rstudio/.workbench
+          ls -lah $(pwd)
+          Rscript -e 'sessionInfo()'
+
+      - name: Mark Repository as Safe
+        run: |
+          git config --global --add safe.directory $(pwd)
+
+      - name: Setup Lesson Dependencies
+        run: |
+          Rscript /home/rstudio/.workbench/setup_lesson_deps.R
+
+      - name: Restore renv from cache
+        id: restore-renv-cache
+        uses: actions/cache@v4
+        if: env.RENV_EXISTS == 'true'
+        with:
+          path: /home/rstudio/lesson/renv
+          key: ${{ runner.os }}-${{ inputs.cache-version }}-renv-${{ needs.prepare.outputs.renv-cache-hashsum }}
+          restore-keys:
+            ${{ runner.os }}-${{ inputs.cache-version }}-renv-
+
+      - name: Restore renv Dependencies
+        if: env.RENV_EXISTS == 'true' && steps.restore-renv-cache.outputs.cache-hit == 'true'
+        run: |
+          lsn_path <- fs::path("/home/rstudio/lesson")
+          renv::load(project = lsn_path)
+          renv_lib  <- renv::paths$library(project = lsn_path)
+          renv_lock <- renv::paths$lockfile(project = lsn_path)
+          renv::restore(project = lsn_path, library = renv_lib, lockfile = renv_lock, prompt = FALSE)
+        shell: Rscript {0}
+
+      - name: Fail on renv cache miss
+        if: env.RENV_EXISTS == 'true' && steps.restore-renv-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "❌ renv cache required but none available. Please run the 'DOCKER Apply Package Cache' workflow."
+          exit 1
+
+      - name: Run Container and Build Site
+        run: |
+          library(sandpaper)
+          sandpaper::package_cache_trigger(TRUE)
+          sandpaper:::ci_deploy(reset = TRUE)
+        shell: Rscript {0}

--- a/inst/workflows/docker_pr_receive.yaml
+++ b/inst/workflows/docker_pr_receive.yaml
@@ -1,0 +1,174 @@
+name: "DOCKER Receive Pull Request"
+
+on:
+  pull_request:
+    types:
+      [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        type: number
+        required: true    
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-pr:
+    name: "Record PR number"
+    if: ${{ github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    outputs:
+      is_valid: ${{ steps.check-pr.outputs.VALID }}
+    steps:
+      - name: "Record PR number"
+        id: record
+        if: ${{ always() }}
+        run: |
+          echo ${{ github.event.number }} > ${{ github.workspace }}/NR # 2022-03-02: artifact name fixed to be NR
+      - name: "Upload PR number"
+        id: upload
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: ${{ github.workspace }}/NR
+      - name: "Get Invalid Hashes File"
+        id: hash
+        run: |
+          echo "json<<EOF
+          $(curl -sL https://files.carpentries.org/invalid-hashes.json)
+          EOF" >> $GITHUB_OUTPUT
+      - name: "echo output"
+        run: |
+          echo "${{ steps.hash.outputs.json }}"
+      - name: "Check PR"
+        id: check-pr
+        uses: carpentries/actions/check-valid-pr@main
+        with:
+          pr: ${{ github.event.number }}
+          invalid: ${{ fromJSON(steps.hash.outputs.json)[github.repository] }}
+
+  check-renv:
+    name: "Check if We Need {renv}"
+    runs-on: ubuntu-latest
+    outputs:
+      renv-needed: ${{ steps.check-for-renv.outputs.exists }}
+    steps:
+      - name: "Checkout Lesson"
+        uses: actions/checkout@v4
+
+      - name: "Check for renv"
+        id: check-for-renv
+        run: |
+          if [[ -d renv ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+
+  prepare:
+    name: "Grab renv.lock hash"
+    runs-on: ubuntu-latest
+    needs: check-renv
+
+    outputs:
+      renv-cache-hashsum: ${{ steps.set-hash.outputs.renv-cache-hashsum }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate renv hash
+        id: set-hash
+        run: |
+          echo "renv-cache-hashsum=${{ hashFiles('renv/profiles/lesson-requirements/renv.lock') }}" >> $GITHUB_OUTPUT
+
+  build-md-source:
+    name: "Build markdown source files if valid"
+    needs:
+      - test-pr
+      - check-renv
+    runs-on: ubuntu-latest
+    if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
+    env:
+      CHIVE: ${{ github.workspace }}/site/chive
+      PR: ${{ github.workspace }}/site/pr
+      GHWMD: ${{ github.workspace }}/site/built
+    permissions:
+      checks: write
+      contents: write
+      pages: write
+    container:
+      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      env:
+        WORKBENCH_PROFILE: "ci"
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        RENV_PATHS_ROOT: /home/rstudio/lesson/renv
+      volumes:
+        - ${{ github.workspace }}:/home/rstudio/lesson
+      options: --cpus 2
+    steps:
+      - name: "Check Out Main Branch"
+        uses: actions/checkout@v4
+
+      - name: "Check Out Staging Branch"
+        uses: actions/checkout@v4
+        with:
+          ref: md-outputs
+          path: ${{ env.GHWMD }}
+
+      - name: Mark Repository as Safe
+        run: |
+          git config --global --add safe.directory $(pwd)
+
+      - name: Setup Lesson Dependencies
+        run: |
+          Rscript /home/rstudio/.workbench/setup_lesson_deps.R
+
+      - name: Fortify renv Cache
+        if: ${{ needs.check-renv.outputs.renv-needed == 'true' }}
+        run: |
+          Rscript /home/rstudio/.workbench/fortify_renv_cache.R
+
+      - name: "Validate and Build Markdown"
+        id: build-site
+        run: |
+          sandpaper::package_cache_trigger(TRUE)
+          sandpaper::validate_lesson(path = '/home/rstudio/lesson')
+          sandpaper:::build_markdown(path = '/home/rstudio/lesson', quiet = FALSE)
+        shell: Rscript {0}
+
+      - name: "Generate Artifacts"
+        id: generate-artifacts
+        run: |
+          sandpaper:::ci_bundle_pr_artifacts(
+            repo         = '${{ github.repository }}',
+            pr_number    = '${{ github.event.number }}',
+            path_md      = '/home/rstudio/lesson/site/built',
+            path_pr      = '/home/rstudio/lesson/site/pr',
+            path_archive = '/home/rstudio/lesson/site/chive',
+            branch       = 'md-outputs'
+          )
+        shell: Rscript {0}
+
+      - name: "Upload PR"
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: ${{ env.PR }}
+          overwrite: true
+
+      - name: "Upload Diff"
+        uses: actions/upload-artifact@v4
+        with:
+          name: diff
+          path: ${{ env.CHIVE }}
+          retention-days: 1
+
+      - name: "Upload Build"
+        uses: actions/upload-artifact@v4
+        with:
+          name: built
+          path: ${{ env.GHWMD }}
+          retention-days: 1
+
+      - name: "Teardown"
+        run: sandpaper::reset_site()
+        shell: Rscript {0}

--- a/inst/workflows/docker_update_cache.yml
+++ b/inst/workflows/docker_update_cache.yml
@@ -1,0 +1,105 @@
+name: "DOCKER Apply Package Cache"
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Who triggered this build?'
+        required: true
+        default: 'Maintainer (via GitHub)'
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  check-renv:
+    name: "Check if We Need {renv}"
+    runs-on: ubuntu-latest
+    outputs:
+      renv-needed: ${{ steps.check-for-renv.outputs.exists }}
+    steps:
+      - name: "Checkout Lesson"
+        uses: actions/checkout@v4
+
+      - name: "Check for renv"
+        id: check-for-renv
+        run: |
+          if [[ -d renv ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+
+  prepare:
+    name: "Grab renv.lock hash"
+    runs-on: ubuntu-latest
+    needs: check-renv
+    if: ${{ needs.check-renv.outputs.renv-needed == 'true' }}
+    outputs:
+      renv-cache-hashsum: ${{ steps.set-hash.outputs.renv-cache-hashsum }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate renv hash
+        id: set-hash
+        run: |
+          echo "renv-cache-hashsum=${{ hashFiles('renv/profiles/lesson-requirements/renv.lock') }}" >> $GITHUB_OUTPUT
+
+  update-renv-cache:
+    name: "Update renv Cache"
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        contains(
+          join(github.event.pull_request.labels.*.name, ','),
+          'type: package cache'
+        )
+      )
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      checks: write
+      contents: write
+      pages: write
+    container:
+      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      env:
+        WORKBENCH_PROFILE: "ci"
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        RENV_PATHS_ROOT: /home/rstudio/lesson/renv
+        RENV_VERSION: ${{ needs.prepare.outputs.renv-cache-hashsum }}
+      volumes:
+        - ${{ github.workspace }}:/home/rstudio/lesson
+      options: --cpus 2
+    steps:
+      - name: "Checkout Lesson"
+        uses: actions/checkout@v4
+
+      - name: Current env
+        run: env | sort
+
+      - name: Debugging Info
+        run: |
+          echo "Current Directory: $(pwd)"
+          ls -lah /home/rstudio/.workbench
+          ls -lah $(pwd)
+          Rscript -e 'sessionInfo()'
+
+      - name: Mark Repository as Safe
+        run: |
+          git config --global --add safe.directory $(pwd)
+
+      - name: Setup Lesson Dependencies
+        run: |
+          Rscript /home/rstudio/.workbench/setup_lesson_deps.R
+
+      - name: Fortify renv Cache
+        run: |
+          Rscript /home/rstudio/.workbench/fortify_renv_cache.R
+
+      - name: Cache renv Directory
+        uses: actions/cache@v4
+        with:
+          path: /home/rstudio/lesson/renv
+          key: ${{ runner.os }}-${{ inputs.cache-version }}-renv-${{ needs.prepare.outputs.renv-cache-hashsum }}
+          restore-keys:
+            ${{ runner.os }}-${{ inputs.cache-version }}-renv-

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   preflight:
     name: "Preflight Check"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       ok: ${{ steps.check.outputs.ok }}
     steps:
@@ -34,47 +34,35 @@ jobs:
             echo "Not Running Today"
           fi
 
-  check_renv:
+  check-renv:
     name: "Check if We Need {renv}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: preflight
     if: ${{ needs.preflight.outputs.ok == 'true'}}
     outputs:
-      needed: ${{ steps.renv.outputs.exists }}
+      renv-needed: ${{ steps.check-for-renv.outputs.exists }}
     steps:
       - name: "Checkout Lesson"
         uses: actions/checkout@v4
-      - id: renv
+      - id: check-for-renv
         run: |
           if [[ -d renv ]]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           fi
 
-  check_token:
-    name: "Check SANDPAPER_WORKFLOW token"
-    runs-on: ubuntu-22.04
-    needs: check_renv
-    if: ${{ needs.check_renv.outputs.needed == 'true' }}
-    outputs:
-      workflow: ${{ steps.validate.outputs.wf }}
-      repo: ${{ steps.validate.outputs.repo }}
-    steps:
-      - name: "validate token"
-        id: validate
-        uses: carpentries/actions/check-valid-credentials@main
-        with:
-          token: ${{ secrets.SANDPAPER_WORKFLOW }}
-
   update_cache:
     name: "Update Package Cache"
-    needs: check_token
-    if: ${{ needs.check_token.outputs.repo== 'true' }}
     runs-on: ubuntu-22.04
+    needs: check-renv
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    if: ${{ needs.check-renv.outputs.renv-needed == 'true' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/.local/share/renv/
     steps:
-
       - name: "Checkout Lesson"
         uses: actions/checkout@v4
 
@@ -95,7 +83,7 @@ jobs:
         if: ${{ steps.update.outputs.n > 0 }}
         uses: carpentries/create-pull-request@main
         with:
-          token: ${{ secrets.SANDPAPER_WORKFLOW }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           delete-branch: true
           branch: "update/packages"
           commit-message: "[actions] update ${{ steps.update.outputs.n }} packages"
@@ -123,3 +111,16 @@ jobs:
             [1]: https://github.com/carpentries/create-pull-request/tree/main
           labels: "type: package cache"
           draft: false
+
+      - name: Skip PR creation
+        if: ${{ steps.update.outputs.n == 0 }}
+        run: |
+          echo "No updates needed, skipping PR creation"
+
+      # thanks @Bisaloo! - https://github.com/carpentries/sandpaper/issues/646#issuecomment-2829578435
+      - name: Trigger checks
+        if: ${{ steps.cpr.outputs.pull-request-number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run docker_pr_receive.yaml --field pr_number=${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
This PR is a fairly consequential update to the sandpaper workflows. The main provisions are:

* Dockerised version of the build_deploy workflow, removing the requirement of sandpaper-main.yml and sandpaper-version.txt. This means the workflow will always `renv::restore` the same cached renv environment for each build rather than updating packages whether intended or not via `remotes::install()` and `sandpaper::manage_deps()`. These functions now are run from within a docker container rather than the workflow itself meaning changes can be pushed to users without needing to update the actual workflow files. This also means locally pinned packages will work in github actions, which they do not currently.
* Dockerised version of the pr_receive workflow, removing the need for the SANDPAPER_TOKEN
* A separate renv cache application workflow that allows users to choose when they want to apply an updated cache and store it as an artifact. This means that build and deployment will use the same renv cache until the user decides to update, reducing maintenance time and support from workbench devs.
* An updated update-cache workflow, removing the need for the SANDPAPER_TOKEN as per https://github.com/carpentries/sandpaper/issues/646 (thanks @Bisaloo!)

This is not yet complete, and we will need testing to be done, and then a formal mechanism to switch to the new dockerised versions, presumably by replacing the existing workflow files, and using the existing update-workflows mechanism to propagate through user's repos.