### PR TITLE
Remove windows 4.1 build due to build failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,8 @@ jobs:
           # - {os: windows-latest, cache: '~\AppData\Local\renv', r: '3.6'}
 
           # use 4.1 to check with rtools40's older compiler
-          - {os: windows-latest, r: '4.1'}
+          # as of 2025-05-01, Windows builds with R4.1 and RTools40/41 fail
+          # - {os: windows-latest, r: '4.1'}
           
           - {os: ubuntu-22.04, cache: '~/.local/share/renv', r: 'release', cov: 'true'}
           


### PR DESCRIPTION
The following tests fail, presumably due to a new inconsistency with R4.1.x, RTools < 41, and pkgdown:

```
== Failed tests ================================================================
-- Failure ('test-build_episode.R:17:3'): build_episode functions works independently --
`pkgdown::init_site(pkg)` did not throw the expected message.
-- Failure ('test-build_html.R:70:3'): (#536) SANDPAPER_SITE envvar works as expected --
`pkgdown::init_site(new_pkg)` did not throw the expected message.
-- Failure ('test-build_html.R:97:3'): [build_home()] works independently ------
`pkgdown::init_site(pkg)` did not throw the expected message.
```

Removing this build step.
