### PR TITLE
Clears the group tab titles after processing a group tab

### DIFF
--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -491,6 +491,7 @@ tab_block = function(el)
   tab_buttons = {}
   this_tab_tabpanel = {}
   tabpanels = {}
+  group_tab_titles = {}
 
   return tabs
 end


### PR DESCRIPTION
Fixes #656 

This ensures on pages with multiple group tabs (which do not share the same tab titles) have the correct id.

```Rmd
---
title: "Debug"
teaching: 30
exercises: 15
---

::: questions

* Why do multiple group-tabs fail?

:::

::: objectives

* Demo group-tabs failing

:::

## Example

We can have one `group-tab`

::: group-tab

### Category A

Category A stuff

### Category B

Category B stuff

:::

and that works

::: group-tab

### Category A

More Category A stuff

### Category B

More Category B stuff

:::

Next set

::: group-tab

### Category C

Category C stuff

### Category D

Category D stuff

### Category E

Category E

:::

more

::: group-tab

### Category C

More Category C stuff

### Category D

More Category D stuff

### Category E

More Category E

:::

::: keypoints

* group-tabs are fixed

:::
```

![image](https://github.com/user-attachments/assets/ea9001c3-7905-4dff-bc81-57885f07a6af)

