### PR TITLE
Move callout type to span in title, keep h3 in inner

### DIFF
--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -213,25 +213,37 @@ fix_callouts <- function(nodes = NULL) {
   h2_text <- xml2::xml_find_all(h2_translate, ".//text()")
   xml_text_translate(h2_text, translations)
 
-  h3 <- xml2::xml_find_all(callouts, "./div/h3")
-  xml2::xml_set_attr(h3, "class", "callout-title")
-  inner_div <- xml2::xml_parent(h3)
-  # remove the "section level3 callout-title" attrs
-  xml2::xml_set_attr(inner_div, "class", "callout-inner")
-  # Get the heading IDS (because we use section headings, the IDs are anchored
-  # to the section div and not the heading element)
-  # <div class="section level3 callout-title callout-inner">
-  #   <h3>Heading for this callout</h3>
-  # </div>
-  ids <- xml2::xml_attr(inner_div, "id")
-  # get the callout ID in the cases where they are missing
-  replacements <- xml2::xml_attr(callouts, "id")
-  ids <- ifelse(is.na(ids), replacements, ids)
-  # add the anchors and then set the attributes in the correct places.
-  add_anchors(h3, ids)
-  xml2::xml_set_attr(h3, "id", NULL)
-  # we replace the callout ID with the correct ID
-  xml2::xml_set_attr(callouts, "id", ids)
+  for (i in seq_along(callouts)) {
+    callout <- callouts[[i]]
+    # if an h3 exists in the callout, we need to set the class
+    h3 <- xml2::xml_find_all(callout, "./div/h3")
+    xml2::xml_set_attr(h3, "class", "callout-title")
+    inner_div <- xml2::xml_parent(h3)
+
+    # if inner_div is null, use parent of callout-header
+    if (length(inner_div) == 0) {
+      print("No inner div found, using parent of h2_translate")
+      outer_div <- xml2::xml_parent(h2_translate)
+      inner_div <- xml2::xml_find_all(outer_div, ".//div[contains(@class, 'callout-inner')]")
+    }
+
+    # remove the "section level3 callout-title" attrs
+    xml2::xml_set_attr(inner_div, "class", "callout-inner")
+    # Get the heading IDS (because we use section headings, the IDs are anchored
+    # to the section div and not the heading element)
+    # <div class="section level3 callout-title callout-inner">
+    #   <h3>Heading for this callout</h3>
+    # </div>
+    ids <- xml2::xml_attr(inner_div, "id")
+    # get the callout ID in the cases where they are missing
+    replacements <- xml2::xml_attr(callout, "id")
+    ids <- ifelse(is.na(ids), replacements, ids)
+    # add the anchors and then set the attributes in the correct places.
+    add_anchors(h3, ids)
+    xml2::xml_set_attr(h3, "id", NULL)
+    # we replace the callout ID with the correct ID
+    xml2::xml_set_attr(callout, "id", ids)
+  }
   invisible(nodes)
 }
 

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -207,11 +207,11 @@ fix_callouts <- function(nodes = NULL) {
   # https://github.com/carpentries/sandpaper/issues/556
   translations <- get_callout_translations()
 
-  # process only h3 titles with no child tags for translation
+  # process only h2 with callout-header class with no child tags for translation
   # https://github.com/carpentries/sandpaper/issues/562
-  h3_translate <- xml2::xml_find_all(callouts, "./div/h3[not(*)]")
-  h3_text <- xml2::xml_find_all(h3_translate, ".//text()")
-  xml_text_translate(h3_text, translations)
+  h2_translate <- xml2::xml_find_all(callouts, ".//h2[@class='callout-header' and not(*)]")
+  h2_text <- xml2::xml_find_all(h2_translate, ".//text()")
+  xml_text_translate(h2_text, translations)
 
   h3 <- xml2::xml_find_all(callouts, "./div/h3")
   xml2::xml_set_attr(h3, "class", "callout-title")

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -222,7 +222,6 @@ fix_callouts <- function(nodes = NULL) {
 
     # if inner_div is null, use parent of callout-header
     if (length(inner_div) == 0) {
-      print("No inner div found, using parent of h2_translate")
       outer_div <- xml2::xml_parent(h2_translate)
       inner_div <- xml2::xml_find_all(outer_div, ".//div[contains(@class, 'callout-inner')]")
     }

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -122,8 +122,7 @@ function get_header(el, level)
   -- check if the header exists
   local header = el.content[1]
   if header == nil or header.level == nil then
-    -- capitalize the first letter and insert it at the top of the block
-    header = pandoc.Header(3, upper_case(class))
+    return(nil)
   else
     header.level = 3
     el.content:remove(1)
@@ -157,14 +156,6 @@ function level_head(el, level)
   -- fix for https://github.com/carpentries/sandpaper/issues/581
   if header == nil then
     return el
-  end
-
-  if level ~= 0 and header.level == nil then
-    -- capitalize the first letter and insert it at the top of the block
-    local C = text.upper(text.sub(class, 1, 1))
-    local lass = text.sub(class, 2, -1)
-    local header = pandoc.Header(level, C..lass)
-    table.insert(el.content, id, header)
   end
 
   if level == 0 and header.level ~= nil then
@@ -239,9 +230,14 @@ accordion = function(el, class)
   local CLASS = upper_case(class)
   local label = CLASS..id
   local title = ""
-  for _, ing in ipairs(get_header(el, 4).content) do
-    title = title..pandoc.utils.stringify(ing)
+
+  header = get_header(el, 4)
+  if not (header == nil) then
+    for _, ing in ipairs(header.content) do
+        title = title..pandoc.utils.stringify(ing)
+    end
   end
+
   if title == CLASS or title == nil or title == "" then
     title = accordion_titles[class]
   end
@@ -511,14 +507,27 @@ callout_block = function(el)
 
   local icon = pandoc.RawBlock("html",
   "<i class='callout-icon' data-feather='"..this_icon.."'></i>")
+
+  local hclass = classes[2]
+  if hclass == nil then
+    hclass = classes[1]
+  end
+
+  local C = text.upper(text.sub(hclass, 1, 1))
+  local lass = text.sub(hclass, 2, -1)
+  local header_text = C..lass
+  local callout_header = pandoc.RawBlock("html",
+  "<h2 class='callout-header'>"..header_text.."</h2>")
+
   local callout_square = pandoc.Div(icon, {class = "callout-square"})
 
-  local callout_inner = pandoc.Div({header}, {class = "callout-inner"})
+  local callout_inner = pandoc.Div({header})
+  callout_inner.classes = {"callout-inner"}
 
   el.classes = {"callout-content"}
   table.insert(callout_inner.content, el)
 
-  local block = pandoc.Div({callout_square, callout_inner})
+  local block = pandoc.Div({callout_square, callout_header, callout_inner})
   block.identifier = callout_id
   block.classes = classes
   return block

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -517,7 +517,7 @@ callout_block = function(el)
   local lass = text.sub(hclass, 2, -1)
   local header_text = C..lass
   local callout_header = pandoc.RawBlock("html",
-  "<h2 class='callout-header'>"..header_text.."</h2>")
+  "<span class='callout-header'>"..header_text.."</span>")
 
   local callout_square = pandoc.Div(icon, {class = "callout-square"})
 

--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -543,6 +543,10 @@ challenge_block = function(el)
   -- If the challenge contains multiple solutions or hints, we need to indicate
   -- that the following challenges/solutions are continuations.
   local this_head = get_header(el, 3)
+  if this_head == nil then
+    -- If there is no header, we create a default one
+    this_head = pandoc.Header(3, "Challenge", {class = "callout-title"})
+  end
   local next_head = this_head:clone()
   next_head.content:insert(pandoc.Emph(" (continued)"))
   next_head.classes = {"callout-title"}

--- a/tests/testthat/_snaps/2.19.2/render_html.md
+++ b/tests/testthat/_snaps/2.19.2/render_html.md
@@ -68,7 +68,7 @@
                   "<i class='callout-icon' data-feather='zap'></i>"
               ]
           , RawBlock
-              (Format "html") "<h2 class='callout-header'>Challenge</h2>"
+              (Format "html") "<span class='callout-header'>Challenge</span>"
           , Div
               ( "" , [ "callout-inner" ] , [] )
               [ Header
@@ -382,7 +382,7 @@
       <div class="callout-square">
       <i class='callout-icon' data-feather='zap'></i>
       </div>
-      <h2 class="callout-header">Challenge</h2>
+      <span class="callout-header">Challenge</span>
       <div class="section level3 callout-title callout-inner">
       <h3 class="callout-title">A Lovely Challenge</h3>
       <div class="callout-content">

--- a/tests/testthat/_snaps/2.19.2/render_html.md
+++ b/tests/testthat/_snaps/2.19.2/render_html.md
@@ -67,10 +67,12 @@
                   (Format "html")
                   "<i class='callout-icon' data-feather='zap'></i>"
               ]
+          , RawBlock
+              (Format "html") "<h2 class='callout-header'>Challenge</h2>"
           , Div
               ( "" , [ "callout-inner" ] , [] )
               [ Header
-                  3 ( "" , [ "callout-title" ] , [] ) [ Str "Challenge" ]
+                  3 ( "" , [ "callout-title" ] , [] ) [ Str "A Lovely Challenge" ]
               , Div
                   ( "" , [ "callout-content" ] , [] )
                   [ Para
@@ -380,8 +382,9 @@
       <div class="callout-square">
       <i class='callout-icon' data-feather='zap'></i>
       </div>
+      <h2 class="callout-header">Challenge</h2>
       <div class="section level3 callout-title callout-inner">
-      <h3 class="callout-title">Challenge</h3>
+      <h3 class="callout-title">A Lovely Challenge</h3>
       <div class="callout-content">
       <p>How do you write markdown divs?</p>
       <p>This <a href="Setup.html">link should be transformed</a></p>

--- a/tests/testthat/examples/callout-ids.html
+++ b/tests/testthat/examples/callout-ids.html
@@ -8,8 +8,8 @@
         <div class="callout-square">
           <i class="callout-icon" data-feather="message-circle"></i>
         </div>
+        <h2 class="callout-header">Challenge (<code>this is code</code>)</h2>
         <div class="section level3 callout-title callout-inner">
-          <h3 class="callout-title">Challenge (<code>this is code</code>)</h3>
           <div class="callout-content">
             <p>How do you write markdown divs?</p>
           </div>
@@ -20,8 +20,8 @@
       <div class="callout-square">
         <i class="callout-icon" data-feather="check"></i>
       </div>
+      <h2 class="callout-header">Wait what?</h2>
       <div id="wait-what" class="section level3 callout-title callout-inner">
-        <h3 class="callout-title">Wait what?</h3>
         <div class="callout-content">
           <p>preeeee</p>
         </div>

--- a/tests/testthat/examples/callout-ids.html
+++ b/tests/testthat/examples/callout-ids.html
@@ -8,7 +8,7 @@
         <div class="callout-square">
           <i class="callout-icon" data-feather="message-circle"></i>
         </div>
-        <h2 class="callout-header">Challenge</h2>
+        <span class="callout-header">Challenge</span>
         <div class="section level3 callout-title callout-inner">
           <h3 class="callout-title" id="code-title">Let's (<code>look at some code</code>)</h3>
           <div class="callout-content">
@@ -21,7 +21,7 @@
       <div class="callout-square">
         <i class="callout-icon" data-feather="check"></i>
       </div>
-      <h2 class="callout-header">Wait what?</h2>
+      <span class="callout-header">Wait what?</span>
       <div id="wait-what" class="section level3 callout-title callout-inner">
         <h3 class="callout-title" id="wait-what-title">What now?</h3>
         <div class="callout-content">
@@ -33,7 +33,7 @@
       <div class="callout-square">
         <i class="callout-icon" data-feather="key"></i>
       </div>
-      <h2 class="callout-header">Key Points</h2>
+      <span class="callout-header">Key Points</span>
       <div id="keypoints" class="section level3 callout-title callout-inner">
         <div class="callout-content">
           <p>Points that are key</p>

--- a/tests/testthat/examples/callout-ids.html
+++ b/tests/testthat/examples/callout-ids.html
@@ -8,8 +8,9 @@
         <div class="callout-square">
           <i class="callout-icon" data-feather="message-circle"></i>
         </div>
-        <h2 class="callout-header">Challenge (<code>this is code</code>)</h2>
+        <h2 class="callout-header">Challenge</h2>
         <div class="section level3 callout-title callout-inner">
+          <h3 class="callout-title" id="code-title">Let's (<code>look at some code</code>)</h3>
           <div class="callout-content">
             <p>How do you write markdown divs?</p>
           </div>
@@ -22,8 +23,20 @@
       </div>
       <h2 class="callout-header">Wait what?</h2>
       <div id="wait-what" class="section level3 callout-title callout-inner">
+        <h3 class="callout-title" id="wait-what-title">What now?</h3>
         <div class="callout-content">
-          <p>preeeee</p>
+          <p>Wait</p>
+        </div>
+      </div>
+    </div>
+    <div id="keypoints1" class="callout checklist">
+      <div class="callout-square">
+        <i class="callout-icon" data-feather="key"></i>
+      </div>
+      <h2 class="callout-header">Key Points</h2>
+      <div id="keypoints" class="section level3 callout-title callout-inner">
+        <div class="callout-content">
+          <p>Points that are key</p>
         </div>
       </div>
     </div>

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -149,7 +149,7 @@ test_that("render_html applies the internal lua filter", {
   ver <- as.character(rmarkdown::pandoc_version())
   non_utf8_windows <- tolower(Sys.info()[["sysname"]]) == "windows" &&
     getRversion() < package_version("4.2.0")
-  skip_if(non_utf8_windows, 
+  skip_if(non_utf8_windows,
     message = "This version of Windows cannot handle UTF-8 strings")
   expect_snapshot(cat(res), transform = formation, variant = ver)
 })

--- a/tests/testthat/test-utils-translate.R
+++ b/tests/testthat/test-utils-translate.R
@@ -339,7 +339,7 @@ test_that("Lessons can be translated with lang setting", {
   )
 
   # Keypoints are always the last block and should be auto-translated
-  xpath_keypoints <- ".//div[@class='callout keypoints']//h3[@class='callout-title']"
+  xpath_keypoints <- ".//div[@class='callout keypoints']//h2[@class='callout-header']"
   keypoints <- xml2::xml_find_first(xml, xpath_keypoints)
   expect_set_translated(keypoints,
     tr_src("computed", "Keypoints")

--- a/tests/testthat/test-utils-translate.R
+++ b/tests/testthat/test-utils-translate.R
@@ -339,7 +339,7 @@ test_that("Lessons can be translated with lang setting", {
   )
 
   # Keypoints are always the last block and should be auto-translated
-  xpath_keypoints <- ".//div[@class='callout keypoints']//h2[@class='callout-header']"
+  xpath_keypoints <- ".//div[@class='callout keypoints']//span[@class='callout-header']"
   keypoints <- xml2::xml_find_first(xml, xpath_keypoints)
   expect_set_translated(keypoints,
     tr_src("computed", "Keypoints")

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -1,4 +1,4 @@
-
+tmp <- res <- restore_fixture()
 
 test_that("paths in instructor view that are nested or not HTML get diverted", {
   html_test <- xml2::read_html(commonmark::markdown_html(c(

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -55,7 +55,7 @@ test_that("(#556) (#454) callout are processed correctly", {
   html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
   fix_callouts(html_test)
   anchors <- xml2::xml_find_all(html_test, ".//a")
-  headings <- xml2::xml_find_all(html_test, ".//h3")
+  headings <- xml2::xml_find_all(html_test, ".//h2")
   callouts <- xml2::xml_find_all(html_test,
     ".//div[starts-with(@class, 'callout ')]")
 

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -55,22 +55,22 @@ test_that("(#556) (#454) callout are processed correctly", {
   html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
   fix_callouts(html_test)
   anchors <- xml2::xml_find_all(html_test, ".//a")
-  headings <- xml2::xml_find_all(html_test, ".//h2")
+  headings <- xml2::xml_find_all(html_test, ".//h2[@class='callout-header']")
   callouts <- xml2::xml_find_all(html_test,
     ".//div[starts-with(@class, 'callout ')]")
 
   # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
   # expect_length(anchors, 2)
 
-  expect_length(callouts, 2)
-  expect_length(headings, 2)
+  expect_length(callouts, 3)
+  expect_length(headings, 3)
   # headings should not have IDS
-  expect_equal(xml2::xml_has_attr(headings, "id"), c(FALSE, FALSE))
+  expect_equal(xml2::xml_has_attr(headings, "id"), c(FALSE, FALSE, FALSE))
   # callouts should have these IDS
-  expect_equal(xml2::xml_has_attr(callouts, "id"), c(TRUE, TRUE))
+  expect_equal(xml2::xml_has_attr(callouts, "id"), c(TRUE, TRUE, TRUE))
   # The IDs should be what we expect
   ids <- xml2::xml_attr(callouts, "id")
-  expect_equal(ids, c("discussion1", "wait-what"))
+  expect_equal(ids, c("discussion1", "wait-what", "keypoints1"))
 
   # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
   # The IDs should match the anchors
@@ -80,7 +80,7 @@ test_that("(#556) (#454) callout are processed correctly", {
   # (https://github.com/carpentries/sandpaper/issues/556)
   htext <- xml2::xml_find_all(headings, ".//text()")
   expect_equal(xml2::xml_text(htext),
-    c("Challenge (", "this is code", ")", "Wait what?"))
+    c("Challenge", "Wait what?", "Key Points"))
 })
 
 

--- a/tests/testthat/test-utils-xml.R
+++ b/tests/testthat/test-utils-xml.R
@@ -55,7 +55,7 @@ test_that("(#556) (#454) callout are processed correctly", {
   html_test <- xml2::read_html(test_path("examples/callout-ids.html"))
   fix_callouts(html_test)
   anchors <- xml2::xml_find_all(html_test, ".//a")
-  headings <- xml2::xml_find_all(html_test, ".//h2[@class='callout-header']")
+  headings <- xml2::xml_find_all(html_test, ".//span[@class='callout-header']")
   callouts <- xml2::xml_find_all(html_test,
     ".//div[starts-with(@class, 'callout ')]")
 
@@ -70,7 +70,7 @@ test_that("(#556) (#454) callout are processed correctly", {
   expect_equal(xml2::xml_has_attr(callouts, "id"), c(TRUE, TRUE, TRUE))
   # The IDs should be what we expect
   ids <- xml2::xml_attr(callouts, "id")
-  expect_equal(ids, c("discussion1", "wait-what", "keypoints1"))
+  expect_equal(ids, c("code-title", "wait-what", "keypoints"))
 
   # temporarily removed as a result of https://github.com/r-lib/pkgdown/issues/2737
   # The IDs should match the anchors


### PR DESCRIPTION
This PR attempts to address https://github.com/carpentries/varnish/issues/160. Not complete as yet.

Paired with https://github.com/carpentries/varnish/pull/new/frog-callout-headers-1

<img width="720" height="521" alt="image" src="https://github.com/user-attachments/assets/ef20de88-baa6-4e4d-a769-dc8e73412c0b" />

<img width="719" height="307" alt="image" src="https://github.com/user-attachments/assets/3bef71f0-3079-4513-83ee-35bc046d1fdc" />
