### PR TITLE
fix: Update varnish lower bound to v1.0.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -118,7 +118,7 @@ Suggests:
     jsonlite,
     sessioninfo,
     mockr,
-    varnish (>= 0.3.0)
+    varnish (>= 1.0.7)
 Additional_repositories: https://carpentries.r-universe.dev/
 Remotes:
   carpentries/pegboard,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 * Support pages with multiple tab groups - PR [658](https://github.com/carpentries/sandpaper/pull/658) (@astroDimitrios)
 * Add distintive callout headers - PR [663](https://github.com/carpentries/sandpaper/pull/663) ([reported](https://github.com/carpentries/varnish/issues/160) @jfrost-mo, implemented @froggleston)
 
+## DEPENDENCIES
+
+* {varnish} minimum version is now 1.0.7
+
 ## MISC
 
 * Fix pak install when trying to parse .editorconfig files (@froggleston)


### PR DESCRIPTION
Resolves #667 

* Update the lower bound on `varnish` to `v1.0.7` for sandpaper `v0.17.0+` as the CSS styling for span callout headers from `varnish` `v1.0.7` is required.
* Note `varnish` lower bound update in NEWS.