### PR TITLE
Add parrot SVG icons instead of superscript text for Glosario links

### DIFF
--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -57,7 +57,7 @@ read_glosario_yaml <- function(glosario, lsn_path = ".") {
 }
 
 # Function to generate the link if the term exists in the glossary
-create_glosario_link <- function(ename, slug, lslug, en_slugs) {
+create_glosario_link <- function(ename, slug, lslug, ldef, en_slugs) {
   current_lang <- this_metadata$get()[["lang"]]
 
   if (slug %in% en_slugs) {
@@ -68,13 +68,23 @@ create_glosario_link <- function(ename, slug, lslug, en_slugs) {
     }
     else {
       url <- paste0("https://glosario.carpentries.org/", current_lang, "/#", slug)
-      # return(paste0("[^", gsub(" ", "\u00A0", as.character(lslug)), "^](", url, ")"))
 
+      ldef <- stringr::str_replace_all(ldef, "\\s+", " ")
+      def_link_pattern <- "\\[([\\-\\s\\w]+)\\]\\(\\#[a-z\\-\\_]+\\)"
+      ldef <- stringr::str_replace_all(
+        ldef,
+        pattern = def_link_pattern,
+        replacement = function(match) {
+          stringr::str_match(match, def_link_pattern)[[2]]
+        }
+      )
+
+      # replace {{ glosario.term }} placeholders with parrots
       return(
         paste0(
           "<a href='", url, "'>",
-          "<sup><img class='parrot' src='assets/images/parrot_icon_colour.svg' height='20' width='20' ",
-          "alt='Glosario: ", lslug, "' title='Glosario: ", lslug, "' ",
+          "<sup><img class='parrot' src='assets/images/parrot_icon_colour.svg' height='18' width='18' ",
+          "alt='Glosario: ", ldef, "' title='Glosario: ", ldef, "'",
           "></sup>",
           "</a>"
         )
@@ -98,7 +108,8 @@ render_glosario_links <- function(path_in, glosario = NULL, quiet = FALSE) {
         replacement = function(match) {
           mterm <- stringr::str_match(match, glos_pattern)[[2]]
           lterm <- glosario[[mterm]][[current_lang]]$term
-          create_glosario_link(basename(path_in), mterm, lterm, slugs)
+          ldef <- glosario[[mterm]][[current_lang]]$def
+          create_glosario_link(basename(path_in), mterm, lterm, ldef, slugs)
         }
       )
 

--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -68,7 +68,17 @@ create_glosario_link <- function(ename, slug, lslug, en_slugs) {
     }
     else {
       url <- paste0("https://glosario.carpentries.org/", current_lang, "/#", slug)
-      return(paste0("[^", gsub(" ", "\u00A0", as.character(lslug)), "^](", url, ")"))
+      # return(paste0("[^", gsub(" ", "\u00A0", as.character(lslug)), "^](", url, ")"))
+
+      return(
+        paste0(
+          "<a href='", url, "'>",
+          "<sup><img class='parrot' src='assets/images/parrot_icon_colour.svg' height='20' width='20' ",
+          "alt='Glosario: ", lslug, "' title='Glosario: ", lslug, "' ",
+          "></sup>",
+          "</a>"
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
Requires varnish https://github.com/carpentries/varnish/pull/177

Also adds [alt and title tooltips](https://www.a11yproject.com/posts/title-attributes/) displaying the definition of a given term in the config.yaml lesson language if a translation is available.