### PR TITLE
Allow CI to bypass the forced manage_deps in renv consent

### DIFF
--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -16,7 +16,7 @@
 #'
 #' @keywords internal
 #' @seealso [build_episode_md()]
-build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE, slug = NULL) {
+build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE, slug = NULL, skip_manage_deps = FALSE) {
 
   # step 1: build the markdown vignettes and site (if it doesn't exist)
   if (rebuild) {
@@ -74,7 +74,7 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE, slug = NU
   needs_building <- fs::path_ext(db$build) %in% c("md", "Rmd")
   if (any(needs_building)) {
     # Render the episode files to the built directory --------------------------
-    renv_check_consent(path, quiet, sources)
+    renv_check_consent(path, quiet, sources, skip_manage_deps)
     # determine if we need to fail when errors are triggered
     fail_on_error <- this_metadata$get()[["fail_on_error"]]
     # this is `error` in the knitr sense of `error = TRUE` means

--- a/R/ci_build.R
+++ b/R/ci_build.R
@@ -44,7 +44,7 @@
 #'
 #' @keywords internal
 #' @rdname ci_build
-ci_build_markdown <- function(path = ".", branch = "md-outputs", remote = "origin", reset = FALSE) {
+ci_build_markdown <- function(path = ".", branch = "md-outputs", remote = "origin", reset = FALSE, skip_manage_deps = TRUE) {
 
   options(sandpaper.use_renv = renv_is_allowed())
 
@@ -80,7 +80,7 @@ ci_build_markdown <- function(path = ".", branch = "md-outputs", remote = "origi
     }
 
     ci_group("Build Markdown Sources")
-    build_markdown(path = path, quiet = FALSE, rebuild = FALSE)
+    build_markdown(path = path, quiet = FALSE, rebuild = FALSE, skip_manage_deps = skip_manage_deps)
     cli::cat_line("::endgroup::")
 
     ci_group("Commit Markdown Sources")

--- a/R/ci_deploy.R
+++ b/R/ci_deploy.R
@@ -13,6 +13,10 @@
 #' @param reset if `TRUE`, the markdown cache is cleared before rebuilding,
 #'   this defaults to `FALSE` meaning the markdown cache will be provisioned
 #'   and used.
+#' @param skip_manage_deps if `FALSE`, dependency management will be processed.
+#'   This defaults to `TRUE` because it is assumed that dependency management
+#'   is handled in the separate package cache update and apply steps in the
+#'   CI workflow, and therefore can be skipped.
 #' @return Nothing, invisibly. This is used for it's side-effect
 #'
 #' @details
@@ -123,7 +127,7 @@
 #' tryCatch(fs::dir_delete(res), error = function() FALSE)
 #' tok <- Sys.time()
 #' cli::cli_alert_info("Elapsed time: {round(tok - tik, 2)} seconds")
-ci_deploy <- function(path = ".", md_branch = "md-outputs", site_branch = "gh-pages", remote = "origin", reset = FALSE) {
+ci_deploy <- function(path = ".", md_branch = "md-outputs", site_branch = "gh-pages", remote = "origin", reset = FALSE, skip_manage_deps = TRUE) {
 
   if (interactive() && is.null(getOption('sandpaper.test_fixture'))) {
     stop("This function is for use on continuous integration only", call. = FALSE)
@@ -136,7 +140,7 @@ ci_deploy <- function(path = ".", md_branch = "md-outputs", site_branch = "gh-pa
 
   # Step 1: build markdown source files
   del_md <- ci_build_markdown(path, branch = md_branch, remote = remote,
-    reset = reset)
+    reset = reset, skip_manage_deps = skip_manage_deps)
   # NOTE: we delete the markdown worktree at the end because we need it for the
   # site to build from the markdown files.
   on.exit(eval(del_md), add = TRUE)

--- a/R/utils-renv.R
+++ b/R/utils-renv.R
@@ -92,10 +92,13 @@ try_use_renv <- function(force = FALSE) {
   invisible(lines)
 }
 
-renv_check_consent <- function(path, quiet, src_files = NULL) {
+renv_check_consent <- function(path, quiet, src_files = NULL, skip_manage_deps = FALSE) {
   has_consent <- getOption("sandpaper.use_renv")
   if (has_consent) {
-    lib <- manage_deps(path, snapshot = TRUE, quiet = quiet)
+    if (!skip_manage_deps) {
+      cli::cli_alert_info("Checking renv dependencies")
+      lib <- manage_deps(path, snapshot = TRUE, quiet = quiet)
+    }
     if (!quiet) {
       cli::cli_alert_info("Using package cache in {renv::paths$root()}")
     }

--- a/man/build_markdown.Rd
+++ b/man/build_markdown.Rd
@@ -4,7 +4,13 @@
 \alias{build_markdown}
 \title{Build plain markdown from the RMarkdown episodes}
 \usage{
-build_markdown(path = ".", rebuild = FALSE, quiet = FALSE, slug = NULL)
+build_markdown(
+  path = ".",
+  rebuild = FALSE,
+  quiet = FALSE,
+  slug = NULL,
+  skip_manage_deps = FALSE
+)
 }
 \arguments{
 \item{path}{the path to your repository (defaults to your current working

--- a/man/ci_build.Rd
+++ b/man/ci_build.Rd
@@ -9,7 +9,8 @@ ci_build_markdown(
   path = ".",
   branch = "md-outputs",
   remote = "origin",
-  reset = FALSE
+  reset = FALSE,
+  skip_manage_deps = TRUE
 )
 
 ci_build_site(
@@ -36,6 +37,11 @@ in \code{\link[=ci_deploy]{ci_deploy()}}
 \item{reset}{if \code{TRUE}, the markdown cache is cleared before rebuilding,
 this defaults to \code{FALSE} meaning the markdown cache will be provisioned
 and used.}
+
+\item{skip_manage_deps}{if \code{FALSE}, dependency management will be processed.
+This defaults to \code{TRUE} because it is assumed that dependency management
+is handled in the separate package cache update and apply steps in the
+CI workflow, and therefore can be skipped.}
 
 \item{md}{the branch name that contains the markdown outputs}
 }

--- a/man/ci_deploy.Rd
+++ b/man/ci_deploy.Rd
@@ -9,7 +9,8 @@ ci_deploy(
   md_branch = "md-outputs",
   site_branch = "gh-pages",
   remote = "origin",
-  reset = FALSE
+  reset = FALSE,
+  skip_manage_deps = TRUE
 )
 }
 \arguments{
@@ -24,6 +25,11 @@ ci_deploy(
 \item{reset}{if \code{TRUE}, the markdown cache is cleared before rebuilding,
 this defaults to \code{FALSE} meaning the markdown cache will be provisioned
 and used.}
+
+\item{skip_manage_deps}{if \code{FALSE}, dependency management will be processed.
+This defaults to \code{TRUE} because it is assumed that dependency management
+is handled in the separate package cache update and apply steps in the
+CI workflow, and therefore can be skipped.}
 }
 \value{
 Nothing, invisibly. This is used for it's side-effect


### PR DESCRIPTION
Even when hydrating existing packages that need no updates, the renv_check_consent mechanism forces manage_deps(). This WIP PR aims to allow CI to bypass this as the update and apply workflows should handle this before any builds would take place.