### PR TITLE
Fix trigger logic and use GHCR images instead of Dockerhub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.18.0
+Version: 0.18.1.9000
 Authors@R: c(
     person(given = "Robert",
            family = "Davey",

--- a/inst/workflows/docker_apply_cache.yaml
+++ b/inst/workflows/docker_apply_cache.yaml
@@ -103,6 +103,14 @@ jobs:
               ) &&
               github.event.pull_request.head.ref == 'update/workflows'
             )
+            ||
+            (
+              contains(
+                join(github.event.pull_request.labels.*.name, ','),
+                'type: docker version'
+              ) &&
+              github.event.pull_request.head.ref == 'update/workbench-docker-version'
+            )
           )
         )
       )
@@ -112,7 +120,7 @@ jobs:
       pages: write
       id-token: write
     container:
-      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      image: ghcr.io/carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
       env:
         WORKBENCH_PROFILE: "ci"
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +208,6 @@ jobs:
           restore-keys:
             ${{ github.repository }}/${{ steps.wb-vers.outputs.container-version }}_renv-
 
-  # trigger the build deploy workflow if update-renv-cache was successful
   trigger-build-deploy:
     name: "Trigger Build and Deploy Workflow"
     runs-on: ubuntu-latest

--- a/inst/workflows/docker_build_deploy.yaml
+++ b/inst/workflows/docker_build_deploy.yaml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths-ignore:
       - '.github/workflows/**.yaml'
+      - '.github/workbench-docker-version.txt'
   schedule:
     - cron: '0 0 * * 2'
   workflow_dispatch:
@@ -83,7 +84,7 @@ jobs:
       pages: write
       id-token: write
     container:
-      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      image: ghcr.io/carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
       env:
         WORKBENCH_PROFILE: "ci"
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/inst/workflows/docker_pr_receive.yaml
+++ b/inst/workflows/docker_pr_receive.yaml
@@ -38,10 +38,10 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "::error::md-outputs branch required but does not exist."
-            echo "::error::Please merge any open package update PRs, and run the '03 Maintain: Apply Package Cache' and '01: Maintain: Build and Deploy Site' workflows."
+            echo "::error::Please merge any open package update PRs to trigger the '03 Maintain: Apply Package Cache' and '01: Maintain: Build and Deploy Site' workflows."
 
             echo "## ❌ ERROR: md-outputs branch required" >> $GITHUB_STEP_SUMMARY
-            echo "Please merge any open package update PRs, and run the '03 Maintain: Apply Package Cache' and '01: Maintain: Build and Deploy Site' workflows." >> $GITHUB_STEP_SUMMARY
+            echo "Please merge any open package update PRs to trigger the '03 Maintain: Apply Package Cache' and '01: Maintain: Build and Deploy Site' workflows." >> $GITHUB_STEP_SUMMARY
 
             exit 1
           fi
@@ -135,9 +135,8 @@ jobs:
       checks: write
       contents: write
       pages: write
-      id-token: write
     container:
-      image: carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
+      image: image: ghcr.io/carpentries/workbench-docker:${{ vars.WORKBENCH_TAG || 'latest' }}
       env:
         WORKBENCH_PROFILE: "ci"
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/inst/workflows/update-cache.yaml
+++ b/inst/workflows/update-cache.yaml
@@ -1,6 +1,8 @@
 name: "02 Maintain: Check for Updated Packages"
 description: "Check for updated R packages and create a pull request to update the lesson's renv lockfile and package cache"
 on:
+  schedule:
+    - cron: '0 0 * * 2'
   workflow_dispatch:
     inputs:
       name:
@@ -22,9 +24,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    # Run every tuesday
-    - cron: '0 0 * * 2'
 
 env:
   LOCKFILE_CACHE_GEN: ${{ vars.LOCKFILE_CACHE_GEN || github.event.inputs.generate-cache || 'false' }}

--- a/inst/workflows/update-workflows.yaml
+++ b/inst/workflows/update-workflows.yaml
@@ -1,6 +1,8 @@
 name: "04 Maintain: Update Workflow Files"
 description: "Update workflow files from the carpentries/sandpaper repository"
 on:
+  schedule:
+    - cron: '0 0 * * 2'
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
Dockerhub limits anonymous pulls to 100 every 6 hours, and as GitHub's runner pools can originate from the same IP across orgs and users, it's likely this would be a problem. This PR works alongside https://github.com/carpentries/workbench-docker/releases/tag/v0.2.3 to use the free unlimited pulls of public packages that GHCR provides.
