### PR TITLE
Add http auth to workflow update GH API calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.20.0
+Version: 0.20.1.9000
 Authors@R: c(
     person(given = "Robert",
            family = "Davey",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sandpaper 0.20.1.9000 []
+
+## HOTFIXES
+
+* Use GITHUB_PAT, GITHUB_TOKEN for fetching JSON from GitHub API URLs when
+  updating workflows (@froggleston)
+
+
 # sandpaper 0.20.0 [2026-02-28]
 
 ## WORKFLOWS

--- a/tests/testthat/_snaps/update_workflows.md
+++ b/tests/testthat/_snaps/update_workflows.md
@@ -3,6 +3,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      i Using GitHub token for authenticated API request.
       i Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       i Workflows/files updated:
       - '.github/workflows/deleteme.yaml' (deleted)
@@ -12,6 +13,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      [36mi[39m Using GitHub token for authenticated API request.
       [36mi[39m Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       [36mi[39m Workflows/files updated:
       - [34m.github/workflows/deleteme.yaml[39m [3m(deleted)[23m
@@ -21,6 +23,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      ℹ Using GitHub token for authenticated API request.
       ℹ Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       ℹ Workflows/files updated:
       - '.github/workflows/deleteme.yaml' (deleted)
@@ -30,6 +33,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      [36mℹ[39m Using GitHub token for authenticated API request.
       [36mℹ[39m Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       [36mℹ[39m Workflows/files updated:
       - [34m.github/workflows/deleteme.yaml[39m [3m(deleted)[23m
@@ -39,6 +43,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      i Using GitHub token for authenticated API request.
       i Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       i Workflows/files updated:
       - '.github/workflows/workflows-version.txt' (modified)
@@ -48,6 +53,7 @@
     Code
       update_github_workflows(tmp, overwrite = FALSE)
     Message
+      i Using GitHub token for authenticated API request.
       i Workflows up-to-date!
 
 ---
@@ -55,6 +61,7 @@
     Code
       update_github_workflows(tmp)
     Message
+      i Using GitHub token for authenticated API request.
       i Downloading workflows from https://api.github.com/repos/carpentries/workbench-workflows/releases/latest
       i Workflows up-to-date!
 

--- a/tests/testthat/test-update_workflows.R
+++ b/tests/testthat/test-update_workflows.R
@@ -60,11 +60,11 @@ test_that("github workflows are recognized as up-to-date", {
     expect_snapshot(update_github_workflows(tmp))
   })
 
-  releases_url <- "https://api.github.com/repos/carpentries/workbench-workflows/releases/latest"
-  releases_json <- jsonlite::fromJSON(releases_url)
-  latest_version_tag <- releases_json$tag_name
-  latest_version <- package_version(gsub("^v", "", latest_version_tag))
-  zip_url <- releases_json$zipball_url
+  release_info <- sandpaper:::fetch_latest_workflows_release_info()
+  latest_version <- release_info$latest_version
+  releases_url <- release_info$releases_url
+  body <- release_info$body
+  zip_url <- release_info$zip_url
 
   temp_zip <- fs::file_temp(ext = ".zip")
   httr::GET(zip_url, httr::write_disk(temp_zip, overwrite = TRUE))


### PR DESCRIPTION
In the latest 0.20.0 release, update-workflows does not support using GITHUB_PAT or GITHUB_TOKEN strings in the `jsonlite::fromJSON` calls to the GitHub API, resulting in occasional GitHub ratelimit timeouts. This means failed jobs will succeed when re-run as and when the rate limit for the given runner IP is removed.

This PR uses httr and passes any PAT in the headers to avoid rate limits.