### PR TITLE
Fix for empty setup.md

### DIFF
--- a/R/build_home.R
+++ b/R/build_home.R
@@ -29,6 +29,12 @@ build_home <- function(pkg, quiet, next_page = NULL) {
   index <- render_html(idx_file)
   if (fs::file_exists(setup)) {
     setup <- render_html(setup)
+    if (setup == "") {
+      # if there is nothing in the page then we build nothing.
+      setup_path <- fs::path(pkg$src_path, "built", "setup.md")
+      cli::cli_alert_warning("Setup {.file {fs::path_rel(setup_path, start = path)}} has no content")
+      setup <- "<p></p>"
+    }
   } else {
     setup <- "<p></p>"
   }

--- a/man/sandpaper-package.Rd
+++ b/man/sandpaper-package.Rd
@@ -45,6 +45,7 @@ Other contributors:
   \item Phil Reed \email{phil.reed@manchester.ac.uk} (\href{https://orcid.org/0000-0002-4479-715X}{ORCID}) [contributor]
   \item Sarah Brown \email{brownsarahm@uri.edu} (\href{https://orcid.org/0000-0001-5728-0822}{ORCID}) [contributor]
   \item Matthew Feickert \email{matthew.feickert@cern.ch} (\href{https://orcid.org/0000-0003-4124-7862}{ORCID}) [contributor]
+  \item Dimitrios Theodorakis \email{astrodimitrios@gmail.com} (\href{https://orcid.org/0000-0001-9288-1332}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
This PR checks for empty setup.md content and warns instead of throwing a similar cryptic error to #677 

Fixes #339 and #383.