### PR TITLE
Removes any brackets from html ids in the tab admonition

### DIFF
--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -372,13 +372,15 @@ tab_filter = {
     if group_tab then
       local tab_id = block_counts["group-tab"]
       local title_no_spaces = title:gsub("%s+", "")
-      id = tab_id.."-"..title_no_spaces
+      -- No spaces and no brackets ()
+      local clean_title = title_no_spaces:gsub("%(%s*", ""):gsub("%s*%)", "")
+      id = tab_id.."-"..clean_title
       -- The JS for the group tabs selects buttons
       -- to show based on the name attribute.
       -- Here we set it to the button title.
-      name = 'name="'..title_no_spaces..'"'
+      name = 'name="'..clean_title..'"'
       -- Store the title so it can be used in the tabpanel id
-      table.insert(group_tab_titles, title_no_spaces)
+      table.insert(group_tab_titles, clean_title)
     else
       local tab_id = block_counts["tab"]
       id = tab_id.."-"..tab_button_num+1


### PR DESCRIPTION
Fixes #711

This removes `(` and `)` from the html IDs used in the tab admonition to switch content. Those brackets are not allowed in the IDs. Tested with the example in #711 if @matthewfeickert could confirm on his end :)