### PR TITLE
Stop removal of h1 title in aggregate pages, add aria-label to codeblock hrefs

### DIFF
--- a/R/build_episode.R
+++ b/R/build_episode.R
@@ -97,16 +97,21 @@ build_episode_html <- function(path_md, path_src = NULL,
   page_globals$metadata$update(c(nav_list, list(date = list(modified = date))))
   page_globals$learner$update(c(nav_list, list(
     body      = use_learner(nodes),
-    progress  = page_progress,
     updated   = date
   )))
+  if (!is.null(page_progress) && !is.na(page_progress)) {
+    page_globals$learner$update(c(nav_list, list(progress = as.character(page_progress))))
+  }
+
   nav_list$page_back <- as_html(nav_list$page_back, instructor = TRUE)
   nav_list$page_forward <- as_html(nav_list$page_forward, instructor = TRUE)
   page_globals$instructor$update(c(nav_list, list(
     body      = use_instructor(nodes),
-    progress  = page_progress,
     updated   = date
   )))
+  if (!is.null(page_progress) && !is.na(page_progress)) {
+    page_globals$instructor$update(c(nav_list, list(progress = as.character(page_progress))))
+  }
 
   build_html(template = "chapter", pkg = pkg, nodes = nodes,
     global_data = page_globals, path_md = path_md, quiet = quiet)

--- a/R/utils-aggregate.R
+++ b/R/utils-aggregate.R
@@ -235,14 +235,18 @@ build_agg_page <- function(pkg, pages, title = NULL, slug = NULL, aggregate = "s
     learn_content <- get_content(agg$learner, content = "self::node()")
     xml2::xml_add_child(learn_content, "section", id = sid)
     learn_parent <- xml2::xml_child(learn_content, xml2::xml_length(learn_content))
-
     instruct_content <- get_content(agg$instructor, content = "self::node()")
     xml2::xml_add_child(instruct_content, "section", id = sid)
     instruct_parent <- xml2::xml_child(instruct_content, xml2::xml_length(instruct_content))
   }
-  # clean up any content that currently exists
-  xml2::xml_remove(xml2::xml_children(learn_parent))
-  xml2::xml_remove(xml2::xml_children(instruct_parent))
+
+  # clean up any content that currently exists, except the content title h1
+  learn_children <- xml2::xml_children(learn_parent)
+  learn_children <- learn_children[!grepl("h1", xml2::xml_name(learn_children))]
+  instruct_children <- xml2::xml_children(instruct_parent)
+  instruct_children <- instruct_children[!grepl("h1", xml2::xml_name(instruct_children))]
+  xml2::xml_remove(learn_children)
+  xml2::xml_remove(instruct_children)
 
   the_episodes <- .resources$get()[["episodes"]]
   the_slugs <- get_slug(the_episodes)
@@ -256,7 +260,7 @@ build_agg_page <- function(pkg, pages, title = NULL, slug = NULL, aggregate = "s
       ep_learn <- pages$learner[[name]]
       ep_instruct <- pages$instructor[[name]]
     }
-    
+
     # skip empty episodes content
     if (is.null(get_content(ep_learn))) {
       next

--- a/R/utils-xml.R
+++ b/R/utils-xml.R
@@ -82,6 +82,21 @@ fix_codeblocks <- function(nodes = NULL) {
     class_headings <- toupper(trimws(xml2::xml_attr(outputs, "class")))
     add_code_heading(outputs, apply_translations(class_headings, translations))
   }
+
+  # get all a nodes with href matching the pattern "cb([0-9]+)-([0-9]+)", capturing the code block id and the output id
+  as <- xml2::xml_find_all(nodes, ".//a[starts-with(@href, '#cb') and contains(@href, '-')]")
+  if (length(as)) {
+    ids <- xml2::xml_attr(as, "href")
+
+    # extract the codeblock id
+    codeblock_ids <- sub("#cb([0-9]+-[0-9]+)", "\\1", ids)
+
+    # add the aria-describedby attribute to the anchor nodes
+    for (i in seq_along(as)) {
+      xml2::xml_set_attr(as[i], "aria-label", paste0("code-block-", codeblock_ids[i]))
+    }
+  }
+
   invisible(nodes)
 }
 

--- a/inst/templates/sidebar_item-template.txt
+++ b/inst/templates/sidebar_item-template.txt
@@ -15,7 +15,7 @@
         {{/current}}
     </div><!--/div.accordion-header-->
         {{#current}}{{#headings}}
-    <div id="flush-collapse{{pos}}" class="accordion-collapse collapse show" aria-labelledby="flush-heading{{pos}}" data-bs-parent="#accordionFlush{{pos}}">
+    <div id="flush-collapse{{pos}}" class="accordion-collapse collapse show" data-bs-parent="#accordionFlush{{pos}}">
       <div class="accordion-body">
         <ul>
           {{{headings}}}


### PR DESCRIPTION
This PR fixes:
- https://github.com/carpentries/varnish/issues/197
- https://github.com/carpentries/varnish/issues/192
- https://github.com/carpentries/varnish/issues/191
- https://github.com/carpentries/varnish/issues/190

