### PR TITLE
Allow simple challenge callouts without accordion blocks

### DIFF
--- a/inst/rmarkdown/lua/lesson.lua
+++ b/inst/rmarkdown/lua/lesson.lua
@@ -555,9 +555,11 @@ challenge_block = function(el)
   -- Once we hit an accordion block, we no longer need the challenge inserted
   -- and any new challenge items go in a new block
   local needs_challenge = true
+  local accordion_seen = false
   for idx, block in ipairs(el.content) do
     if block.classes ~= nil and block.classes[1] == "accordion" then
       if needs_challenge then
+        accordion_seen = true
         challenge_train:insert(callout_block(this_challenge))
         this_challenge = pandoc.Div({next_head}, {class = "challenge"})
         needs_challenge = false
@@ -575,8 +577,12 @@ challenge_block = function(el)
   end
   -- Fencepost
   if #this_challenge.content > 1 then
-    bookend = pandoc.Div(this_challenge.content, {class = "discussion"})
-    challenge_train:insert(callout_block(bookend))
+    if accordion_seen then
+      bookend = pandoc.Div(this_challenge.content, {class = "discussion"})
+      challenge_train:insert(callout_block(bookend))
+    else
+      challenge_train:insert(callout_block(this_challenge))
+    end
   end
   return(challenge_train)
 end

--- a/tests/testthat/examples/challenge-multi.md
+++ b/tests/testthat/examples/challenge-multi.md
@@ -21,3 +21,9 @@ USE THE BARD
 Did you use the resources available to you? Did you lean on your traits?
 
 :::
+
+::: challenge
+
+Repeat the encounter using the cleric instead
+
+:::

--- a/tests/testthat/test-render_html.R
+++ b/tests/testthat/test-render_html.R
@@ -184,12 +184,13 @@ test_that("accordion lua filter parses challenge accordions correctly", {
 
 example_challenge2 <- fs::path_abs(test_path("examples", "challenge-multi.md"))
 
-test_that("accordion lua filter parses post-solution text accordingly", {
+test_that("accordion lua filter parses post-solution and no-solution text accordingly", {
   skip_if_not(rmarkdown::pandoc_available("2.11"))
   res <- render_html(example_challenge2)
   expect_match(res, "<div id=\"accordionHint1\"", fixed = TRUE)
   expect_match(res, "<div id=\"accordionSolution1\"", fixed = TRUE)
   expect_match(res, "<div id=\"discussion1\"", fixed = TRUE)
+  expect_match(res, "<div id=\"challenge2\"", fixed = TRUE)
 })
 
 


### PR DESCRIPTION
The accordion lua filter for challenge blocks is set up to transform a structure like this:

- div.challenge
    - (question)
    - div.hint / div.solution
        - (answer)
    - (debrief)

into a structure like this:

- div.challenge
    - (question)
- div.hint / div.solution
    - (answer)
- div.discussion
    - (debrief)

But it does this (in effect) by taking away all the content up to the last inner block, and assuming that whatever is left must be a debrief discussion. This does not take into account the possibility that there were no inner blocks to begin with, and means that

- div.challenge
    - (set of steps to try)
 
is transformed into

- div.discussion
    - (set of steps to try)

This PR changes that behaviour so the filter will only put the content at the end of a div.challenge into a div.discussion if at least one div.challenge has already been added to the challenge train; otherwise it will just add the current div.challenge to the train unaltered. I have done this with an additional local Boolean, as I think this is marginally more efficient in Lua than checking for an empty pandoc.List with `next(...) == nil` but I'm prepared to be corrected on that.

I have added a unit test for this behaviour, which the old code fails and the new code passes.

Fixes #672.