### PR TITLE
Fix continuous rebuild of glossary page

### DIFF
--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -271,38 +271,41 @@ build_glossary_page <- function(pkg, pages, title = "Glosario Links", slug = "re
 
   learner_outpath <- fs::path(pkg$dst_path, "reference.html")
   instructor_outpath <- fs::path(pkg$dst_path, "instructor", "reference.html")
+  outpaths <- c(learner_outpath, instructor_outpath)
 
-  for (outpath in c(learner_outpath, instructor_outpath)) {
+  already_built <- template_check$valid() && any(fs::file_exists(outpaths))
+
+  if (already_built) {
+    built_path <- fs::path(pkg$src_path, "built")
+
+    # delete existing reference files and rebuild once from scratch
+    for (outpath in outpaths[fs::file_exists(outpaths)]) {
+      fs::file_delete(outpath)
+    }
+
+    build_episode_html(
+      path_md = fs::path(built_path, "reference.md"),
+      pkg = pkg,
+      quiet = quiet,
+      glosario = glosario
+    )
+  }
+
+  for (outpath in outpaths) {
     out <- fs::path_rel(outpath, pkg$dst_path)
 
-    already_built <- template_check$valid() && fs::file_exists(outpath)
-
     if (already_built) {
-        report <- "Rebuilding '{.file {out}}'"
-        if (!quiet) cli::cli_text(report)
-
-        # delete the existing reference.html file
-        fs::file_delete(outpath)
-
-        built_path <- fs::path(pkg$src_path, "built")
-
-        # rebuild from scratch using build_episode_html
-        build_episode_html(
-        path_md = fs::path(built_path, "reference.md"),
-        pkg = pkg,
-        quiet = quiet,
-        glosario = glosario
-        )
+      report <- "Rebuilding '{.file {out}}'"
     }
     else {
-        report <- "Appending to '{.file {out}}'"
-        if (!quiet) cli::cli_text(report)
+      report <- "Appending to '{.file {out}}'"
     }
+
+    if (!quiet) cli::cli_text(report)
 
     ref_html <- xml2::read_html(outpath)
     ref_sect <- xml2::xml_find_first(ref_html, ".//main/div[contains(@class, 'lesson-content')]")
-    xml2::xml_add_child(ref_sect, agg_sect)
-    if (!quiet) cli::cli_text(report)
+    xml2::xml_add_child(ref_sect, agg_sect, .copy = TRUE)
     writeLines(as.character(ref_html), outpath)
   }
 }

--- a/R/build_glossary.R
+++ b/R/build_glossary.R
@@ -175,6 +175,7 @@ build_glossary <- function(pkg, pages = NULL, quiet = FALSE) {
 build_glossary_page <- function(pkg, pages, title = "Glosario Links", slug = "reference", aggregate = "*", append = "self::node()", quiet = FALSE) {
   path <- get_source_path() %||% root_path(pkg$src_path)
   out_path <- pkg$dst_path
+
   this_lesson(path)
 
   lang <- this_metadata$get()[["lang"]]
@@ -268,38 +269,42 @@ build_glossary_page <- function(pkg, pages, title = "Glosario Links", slug = "re
     xml2::xml_add_child(agg_li, def)
   }
 
-  outpath <- fs::path(pkg$dst_path, "reference.html")
-  out <- fs::path_rel(outpath, pkg$dst_path)
+  learner_outpath <- fs::path(pkg$dst_path, "reference.html")
+  instructor_outpath <- fs::path(pkg$dst_path, "instructor", "reference.html")
 
-  already_built <- template_check$valid() && fs::file_exists(outpath)
+  for (outpath in c(learner_outpath, instructor_outpath)) {
+    out <- fs::path_rel(outpath, pkg$dst_path)
 
-  if (already_built) {
-    report <- "Rebuilding '{.file {out}}'"
+    already_built <- template_check$valid() && fs::file_exists(outpath)
+
+    if (already_built) {
+        report <- "Rebuilding '{.file {out}}'"
+        if (!quiet) cli::cli_text(report)
+
+        # delete the existing reference.html file
+        fs::file_delete(outpath)
+
+        built_path <- fs::path(pkg$src_path, "built")
+
+        # rebuild from scratch using build_episode_html
+        build_episode_html(
+        path_md = fs::path(built_path, "reference.md"),
+        pkg = pkg,
+        quiet = quiet,
+        glosario = glosario
+        )
+    }
+    else {
+        report <- "Appending to '{.file {out}}'"
+        if (!quiet) cli::cli_text(report)
+    }
+
+    ref_html <- xml2::read_html(outpath)
+    ref_sect <- xml2::xml_find_first(ref_html, ".//main/div[contains(@class, 'lesson-content')]")
+    xml2::xml_add_child(ref_sect, agg_sect)
     if (!quiet) cli::cli_text(report)
-
-    # delete the existing reference.html file
-    fs::file_delete(outpath)
-
-    built_path <- fs::path(pkg$src_path, "built")
-
-    # rebuild from scratch using build_episode_html
-    build_episode_html(
-      path_md = fs::path(built_path, "reference.md"),
-      pkg = pkg,
-      quiet = quiet,
-      glosario = glosario
-    )
+    writeLines(as.character(ref_html), outpath)
   }
-  else {
-    report <- "Appending to '{.file {out}}'"
-    if (!quiet) cli::cli_text(report)
-  }
-
-  ref_html <- xml2::read_html(outpath)
-  ref_sect <- xml2::xml_find_first(ref_html, ".//main/div[contains(@class, 'lesson-content')]")
-  xml2::xml_add_child(ref_sect, agg_sect)
-  if (!quiet) cli::cli_text(report)
-  writeLines(as.character(ref_html), outpath)
 }
 
 get_glossary_links <- function(episode, episode_name, glosario) {

--- a/tests/testthat/test-build_glossary.R
+++ b/tests/testthat/test-build_glossary.R
@@ -1,0 +1,41 @@
+
+tmp <- res <- restore_fixture()
+
+metadata_json <- trimws(create_metadata_jsonld(tmp))
+sitepath <- fs::path(tmp, "site", "docs")
+pkg <- pkgdown::as_pkgdown(fs::path_dir(sitepath))
+
+config_path <- fs::path(tmp, "config.yaml")
+config <- yaml::read_yaml(config_path)
+config$lang <- "de"
+glosario_path <- fs::path(tmp, "glossary.yml")
+yaml::write_yaml(
+  list(
+    list(
+      slug = "algorithm",
+      en = list(
+        term = "Algorithm",
+        def = "A sequence of steps to solve a problem."
+      ),
+      de = list(
+        term = "Algorithmus",
+        def = "Eine Folge von Schritten, um ein Problem zu losen."
+      )
+    )
+  ),
+  glosario_path
+)
+config$glosario <- "glossary.yml"
+yaml::write_yaml(config, config_path)
+
+test_that("Glossary files are present and have the correct elements", {
+
+  skip_if_not(rmarkdown::pandoc_available("2.11"))
+
+  # Build the lesson with the new 'de' config
+  suppressMessages(build_lesson(tmp, preview = FALSE, quiet = TRUE))
+  ref <- fs::path(sitepath, "reference.html")
+
+  content <- get_content(ref, "/section[@id='glosario']", pkg = pkg, instructor = FALSE)
+  expect_length(content, 1L)
+})

--- a/tests/testthat/test-build_html.R
+++ b/tests/testthat/test-build_html.R
@@ -43,6 +43,9 @@ test_that("(#536) SANDPAPER_SITE envvar works as expected", {
   tmp <- withr::local_tempdir("site")
   withr::local_envvar(list("SANDPAPER_SITE" = tmp))
 
+  # set explicit source root path rather than relying on the order of tests to set it up
+  set_source_path(res)
+
   # setting the envvar doesn't actually create the built folder
   expect_false(fs::file_exists(fs::path(tmp, "_pkgdown.yaml")))
   create_site(res)

--- a/tests/testthat/test-build_lesson.R
+++ b/tests/testthat/test-build_lesson.R
@@ -454,22 +454,3 @@ test_that("episodes with HTML in the title are rendered correctly", {
         fixed = TRUE
   )))
 })
-
-tmp <- res <- restore_fixture()
-config_path <- fs::path(tmp, "config.yaml")
-config <- yaml::read_yaml(config_path)
-config$lang <- "de"
-config$glosario <- "true"
-yaml::write_yaml(config, config_path)
-
-test_that("Glossary files are present and have the correct elements", {
-
-  skip_if_not(rmarkdown::pandoc_available("2.11"))
-
-  # Build the lesson with the new 'de' config
-  suppressMessages(build_lesson(tmp, preview = FALSE, quiet = TRUE))
-
-  ref <- fs::path(sitepath, "reference.html")
-  content <- get_content(ref, "/section[@id='glosario']", pkg = pkg, instructor = FALSE)
-  expect_length(content, 1L)
-})


### PR DESCRIPTION
When using `sandpaper::serve()` and editing markdown in real time to do continuous builds and testing, the rebuild of the glossary page when Glosario is enabled fails with:

```
── Indexing Glosario links ───────────
Appending to 'reference.html'
<error/rlang_error>
Error in `path_to_connection()`:
! .../site/docs/reference.html does not exist
---
Backtrace:
     ▆
  1. └─httpuv (local) `<fn>`(`<externalptr>`, FALSE, "/02_resourcerequirements.html")
  2.   ├─base::try(handler(binary, message))
  3.   │ └─base::tryCatch(...)
  4.   │   └─base (local) tryCatchList(expr, classes, parentenv, handlers)
  5.   │     └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
  6.   │       └─base (local) doTryCatch(return(expr), name, parentenv, handler)
  7.   └─servr (local) handler(binary, message)
  8.     ├─xfun::in_dir(...)
  9.     ├─ws$send(...)
 10.     ├─base::tryCatch(...)
 11.     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 12.     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 13.     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 14.     ├─jsonlite::toJSON(build(message), auto_unbox = TRUE, null = "null")
 15.     │ └─base::force(x)
 16.     └─servr (local) build(message)
 17.       └─sandpaper (local) handler(c(f3, na.omit(f5)))
 18.         └─sandpaper::build_lesson(f, preview = FALSE, quiet = quiet)
 19.           └─sandpaper:::build_site(...)
 20.             └─sandpaper:::build_glossary(pkg, pages = html_pages, quiet = quiet)
 21.               └─sandpaper:::build_glossary_page(...)
 22.                 ├─xml2::read_html(outpath)
 23.                 └─xml2:::read_html.default(outpath)
 24.                   ├─base::suppressWarnings(...)
 25.                   │ └─base::withCallingHandlers(...)
 26.                   ├─xml2::read_xml(x, encoding = encoding, ..., as_html = TRUE, options = options)
 27.                   └─xml2:::read_xml.character(...)
```

This is due to the `instructor/reference.html` page existing, but the learner `reference.html` not existing at the time of the rebuild. This PR ensures that both instructor and learner pages are rebuilt.

```
── Indexing Glosario links  ──────────────────────────────────────────────────────────
Rebuilding 'reference.html'
Writing `instructor/reference.html`
Writing `reference.html`
Rebuilding 'reference.html'
```