### PR TITLE
Add nanonext for pkgdown 2.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -119,7 +119,8 @@ Imports:
     stringr,
     httr,
     R.utils,
-    xfun
+    xfun,
+    nanonext (>= 1.8.0),
 Suggests:
     testthat (>= 3.0.0),
     covr,


### PR DESCRIPTION
Import nanonext for site previewing via `pkgdown::preview_site()` as per: https://github.com/r-lib/pkgdown/pull/2975