### PR TITLE
Make previous, next breadcrumbs longer

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -115,11 +115,11 @@ get_trimmed_title <- function(next_page) {
   }
   next_title <- strsplit(next_page$pagetitle, "\\s")[[1]]
   # only allow titles up to 20 characters long
-  ok <- (cumsum(nchar(next_title)) + (seq(next_title) - 1)) <= 20
+  ok <- (cumsum(nchar(next_title)) + (seq(next_title) - 1)) <= 40
   if (sum(ok) > 0) {
     parse_title(paste(next_title[ok], collapse = " "))
   } else {
-    parse_title(substr(next_page$pagetitle, 1, 20))
+    parse_title(substr(next_page$pagetitle, 1, 40))
   }
 }
 


### PR DESCRIPTION
The length of breadcrumbs was a little short at 20 characters, meaning that the title of episodes was truncated even when there was space to fit it in, given page widths.

This is now 40 characters.